### PR TITLE
Fix implicit conversion warnings by casting

### DIFF
--- a/sm2.c
+++ b/sm2.c
@@ -68,10 +68,10 @@ static int ecc_sm2_digest_hashin(wc_HashAlg* hash, enum wc_HashType hashType,
     word32 tmpSz;
 
     /* Number of bytes in binary as type word32. */
-    tmpSz = hexSz;
+    tmpSz = (word32)hexSz;
     if (err == 0) {
         /* Convert hexadecimal string to binary. */
-        err = Base16_Decode((const byte*)hexIn, hexSz, tmp, &tmpSz);
+        err = Base16_Decode((const byte*)hexIn, tmpSz, tmp, &tmpSz);
     }
     if (err == 0) {
         /* Update the hash with the binary data. */
@@ -115,8 +115,8 @@ static int _ecc_sm2_calc_za(const byte *id, word16 idSz,
     /* Get ID of A size in bits. */
     sz = idSz * WOLFSSL_BIT_SIZE;
     /* Set big-endian 16-bit word. */
-    entla[0] = sz >> WOLFSSL_BIT_SIZE;
-    entla[1] = sz & 0xFF;
+    entla[0] = (byte)(sz >> WOLFSSL_BIT_SIZE);
+    entla[1] = (byte)(sz & 0xFF);
 
 #ifdef DEBUG_ECC_SM2
     WOLFSSL_MSG("ENTLA");
@@ -124,7 +124,7 @@ static int _ecc_sm2_calc_za(const byte *id, word16 idSz,
 #endif
 
     /* Get ordinate size. */
-    xASz = yASz = wc_ecc_size(key);
+    xASz = yASz = (word32)wc_ecc_size(key);
 #ifdef WOLFSSL_SMALL_STACK
     /* Allocate memory for the x-ordinate. */
     xA = (byte*)XMALLOC(xASz  + 1, key->heap, DYNAMIC_TYPE_TMP_BUFFER);
@@ -233,11 +233,11 @@ static int _ecc_sm2_calc_msg_hash(const byte* za, int zaSz, const byte* msg,
     err = wc_HashInit_ex(hash, hashType, NULL, 0);
     if (err == 0) {
         /* Hash ZA. */
-        err = wc_HashUpdate(hash, hashType, za, zaSz);
+        err = wc_HashUpdate(hash, hashType, za, (word32)zaSz);
     }
     if (err == 0) {
         /* Hash the message. */
-        err = wc_HashUpdate(hash, hashType, msg, msgSz);
+        err = wc_HashUpdate(hash, hashType, msg, (word32)msgSz);
     }
     if (err == 0) {
         /* Output the hash. */

--- a/sm3.c
+++ b/sm3.c
@@ -977,7 +977,7 @@ int wc_Sm3Update(wc_Sm3* sm3, const byte* data, word32 len)
     }
     if ((ret == 0) && (len >= WC_SM3_BLOCK_SIZE)) {
         /* Mask out bits that are not a multiple of 64. */
-        word32 l = len & (~(WC_SM3_BLOCK_SIZE - 1));
+        word32 l = len & (word32)(~(WC_SM3_BLOCK_SIZE - 1));
 
         /* Compress complete blocks of data. */
         SM3_COMPRESS_LEN(sm3, data, l);
@@ -1030,7 +1030,8 @@ static WC_INLINE void sm3_last_block(wc_Sm3* sm3)
 
 #ifdef LITTLE_ENDIAN_ORDER
     /* Reverse as many words as had data in them. (Reverse of 0 is 0). */
-    ByteReverseWords(sm3->buffer, sm3->buffer, (sm3->buffLen + 3) & (~3));
+    ByteReverseWords(sm3->buffer, sm3->buffer,
+        (sm3->buffLen + 3) & (word32)(~3));
 #endif
     /* Hash last block. */
     sm3_final(sm3);

--- a/sm4.c
+++ b/sm4.c
@@ -1070,7 +1070,7 @@ int wc_Sm4CtrEncrypt(wc_Sm4* sm4, byte* out, const byte* in, word32 sz)
             out += len;
             sz -= len;
             /* Some or all unused bytes used up. */
-            sm4->unused -= len;
+            sm4->unused -= (byte)len;
         }
 
         /* Do blocks at a time - only get here when there are no unused bytes.
@@ -1098,7 +1098,7 @@ int wc_Sm4CtrEncrypt(wc_Sm4* sm4, byte* out, const byte* in, word32 sz)
             /* XOR the encrypted IV with remaining data into output. */
             xorbufout(out, in, sm4->tmp, sz);
             /* Record number of unused encrypted IV bytes. */
-            sm4->unused = SM4_BLOCK_SIZE - sz;
+            sm4->unused = (byte)(SM4_BLOCK_SIZE - sz);
         }
     }
 
@@ -1375,7 +1375,7 @@ static int sm4_gcm_decrypt_c(wc_Sm4* sm4, byte* out, const byte* in, word32 sz,
 
     #ifndef WC_SM4_GCM_DEC_AUTH_EARLY
         /* Compare tag and calculated tag in constant time. */
-        res = ConstantCompare(tag, calcTag, tagSz);
+        res = ConstantCompare(tag, calcTag, (int)tagSz);
         /* Create mask based on comparison result in constant time */
         res = 0 - (sword32)(((word32)(0 - res)) >> 31U);
         /* Mask error code to get return value. */
@@ -1467,7 +1467,7 @@ int wc_Sm4GcmEncrypt(wc_Sm4* sm4, byte* out, const byte* in, word32 sz,
 
     if (ret == 0) {
     #ifdef OPENSSL_EXTRA
-        sm4->nonceSz = nonceSz;
+        sm4->nonceSz = (int)nonceSz;
     #endif
         /* Perform encryption using C implementation. */
         sm4_gcm_encrypt_c(sm4, out, in, sz, nonce, nonceSz, tag, tagSz, aad,
@@ -1526,7 +1526,7 @@ int wc_Sm4GcmDecrypt(wc_Sm4* sm4, byte* out, const byte* in, word32 sz,
 
     if (ret == 0) {
     #ifdef OPENSSL_EXTRA
-        sm4->nonceSz = nonceSz;
+        sm4->nonceSz = (int)nonceSz;
     #endif
         /* Perform decryption using C implementation. */
         ret = sm4_gcm_decrypt_c(sm4, out, in, sz, nonce, nonceSz, tag, tagSz,
@@ -1597,10 +1597,10 @@ static void sm4_ccm_roll_aad(wc_Sm4* sm4, const byte* in, word32 sz, byte* out)
         aadLenSz = 6;
         out[0] ^= 0xFF;
         out[1] ^= 0xFE;
-        out[2] ^= ((sz & 0xFF000000) >> 24);
-        out[3] ^= ((sz & 0x00FF0000) >> 16);
-        out[4] ^= ((sz & 0x0000FF00) >>  8);
-        out[5] ^=  (sz & 0x000000FF);
+        out[2] ^= (byte)((sz & 0xFF000000) >> 24);
+        out[3] ^= (byte)((sz & 0x00FF0000) >> 16);
+        out[4] ^= (byte)((sz & 0x0000FF00) >>  8);
+        out[5] ^= (byte) (sz & 0x000000FF);
     }
 
     /* Calculate number of input bytes required to make up the block. */
@@ -1715,11 +1715,11 @@ static WC_INLINE void sm4_ccm_calc_auth_tag(wc_Sm4* sm4, const byte* plain,
     /* Nonce is in place. */
 
     /* Set first byte to length and flags. */
-    b[0] = (((aad != NULL) && (aadSz > 0)) ? 0x40 : 0x00) +
-           (8 * (((byte)tagSz - 2) / 2)) + (ctrSz - 1);
+    b[0] = (byte)((((aad != NULL) && (aadSz > 0)) ? 0x40 : 0x00) +
+                  (8 * (((byte)tagSz - 2) / 2)) + (ctrSz - 1));
     /* Set the counter bytes to length of data - 4 bytes of length only. */
     for (i = 0; i < ctrSz && i < sizeof(word32); i++) {
-        b[SM4_BLOCK_SIZE - 1 - i] = sz >> (8 * i);
+        b[SM4_BLOCK_SIZE - 1 - i] = (byte)(sz >> (8 * i));
     }
     /* Set remaining counter bytes to 0. */
     for (; i < ctrSz; i++) {
@@ -1835,7 +1835,7 @@ static int sm4_ccm_decrypt_c(wc_Sm4* sm4, byte* out, const byte* in, word32 sz,
     sm4_ccm_calc_auth_tag(sm4, out, sz, aad, aadSz, b, ctrSz, t, tagSz);
 
     /* Compare calculated tag with passed in tag. */
-    if (ConstantCompare(t, tag, tagSz) != 0) {
+    if (ConstantCompare(t, tag, (int)tagSz) != 0) {
         /* Set CCM authentication error return. */
         ret = SM4_CCM_AUTH_E;
     }
@@ -1893,7 +1893,7 @@ int wc_Sm4CcmEncrypt(wc_Sm4* sm4, byte* out, const byte* in, word32 sz,
 
     if (ret == 0) {
     #ifdef OPENSSL_EXTRA
-        sm4->nonceSz = nonceSz;
+        sm4->nonceSz = (int)nonceSz;
     #endif
         /* Perform encryption using C implementation. */
         sm4_ccm_encrypt_c(sm4, out, in, sz, nonce, nonceSz, tag, tagSz, aad,
@@ -1955,7 +1955,7 @@ int wc_Sm4CcmDecrypt(wc_Sm4* sm4, byte* out, const byte* in, word32 sz,
 
     if (ret == 0) {
     #ifdef OPENSSL_EXTRA
-        sm4->nonceSz = nonceSz;
+        sm4->nonceSz = (int)nonceSz;
     #endif
         /* Perform decryption using C implementation. */
         ret = sm4_ccm_decrypt_c(sm4, out, in, sz, nonce, nonceSz, tag, tagSz,


### PR DESCRIPTION
"gcc -Wconversion" warned about implicit conversions. Have to have explicit conversions, so casts added.