### PR TITLE
SM2 sign: reduce s to less than order

### DIFF
--- a/scripts/sp/ecc_sm2.rb
+++ b/scripts/sp/ecc_sm2.rb
@@ -357,6 +357,11 @@ EOF
                 sp_#{@total}_mont_mul_order_#{@namef}#{@words}(s, s, xInv);
             sp_#{@total}_norm_#{@words}(s);
 
+            c = sp_#{@total}_cmp_#{@namef}#{@words}(s, #{@cname}_order);
+            sp_#{@total}_cond_sub_#{@namef}#{@words}(s, s, #{@cname}_order,
+                0L - (sp_digit)(c >= 0));
+            sp_#{@total}_norm_#{@words}(s);
+
             /* Check that signature is usable. */
             if (sp_#{@total}_iszero_#{@words}(s) == 0) {
                 break;

--- a/sm3_asm.S
+++ b/sm3_asm.S
@@ -1,5 +1,5 @@
-/* sm3_asm
- *
+/* sm3_asm.S */
+/*
  * Copyright (C) 2006-2023 wolfSSL Inc.
  *
  * This file is part of wolfSSL.

--- a/sm3_asm.asm
+++ b/sm3_asm.asm
@@ -1,5 +1,5 @@
-; /* sm3_asm
-;  *
+; /* sm3_asm.asm */
+; /*
 ;  * Copyright (C) 2006-2023 wolfSSL Inc.
 ;  *
 ;  * This file is part of wolfSSL.

--- a/sp_sm2_arm32.c
+++ b/sp_sm2_arm32.c
@@ -16490,6 +16490,11 @@ int sp_ecc_sign_sm2_256(const byte* hash, word32 hashLen, WC_RNG* rng,
                 sp_256_mont_mul_order_sm2_8(s, s, xInv);
             sp_256_norm_8(s);
 
+            c = sp_256_cmp_sm2_8(s, p256_sm2_order);
+            sp_256_cond_sub_sm2_8(s, s, p256_sm2_order,
+                0L - (sp_digit)(c >= 0));
+            sp_256_norm_8(s);
+
             /* Check that signature is usable. */
             if (sp_256_iszero_8(s) == 0) {
                 break;

--- a/sp_sm2_arm64.c
+++ b/sp_sm2_arm64.c
@@ -19567,6 +19567,11 @@ int sp_ecc_sign_sm2_256(const byte* hash, word32 hashLen, WC_RNG* rng,
                 sp_256_mont_mul_order_sm2_4(s, s, xInv);
             sp_256_norm_4(s);
 
+            c = sp_256_cmp_sm2_4(s, p256_sm2_order);
+            sp_256_cond_sub_sm2_4(s, s, p256_sm2_order,
+                0L - (sp_digit)(c >= 0));
+            sp_256_norm_4(s);
+
             /* Check that signature is usable. */
             if (sp_256_iszero_4(s) == 0) {
                 break;

--- a/sp_sm2_armthumb.c
+++ b/sp_sm2_armthumb.c
@@ -9295,6 +9295,11 @@ int sp_ecc_sign_sm2_256(const byte* hash, word32 hashLen, WC_RNG* rng,
                 sp_256_mont_mul_order_sm2_8(s, s, xInv);
             sp_256_norm_8(s);
 
+            c = sp_256_cmp_sm2_8(s, p256_sm2_order);
+            sp_256_cond_sub_sm2_8(s, s, p256_sm2_order,
+                0L - (sp_digit)(c >= 0));
+            sp_256_norm_8(s);
+
             /* Check that signature is usable. */
             if (sp_256_iszero_8(s) == 0) {
                 break;

--- a/sp_sm2_c32.c
+++ b/sp_sm2_c32.c
@@ -5823,6 +5823,11 @@ int sp_ecc_sign_sm2_256(const byte* hash, word32 hashLen, WC_RNG* rng,
                 sp_256_mont_mul_order_sm2_9(s, s, xInv);
             sp_256_norm_9(s);
 
+            c = sp_256_cmp_sm2_9(s, p256_sm2_order);
+            sp_256_cond_sub_sm2_9(s, s, p256_sm2_order,
+                0L - (sp_digit)(c >= 0));
+            sp_256_norm_9(s);
+
             /* Check that signature is usable. */
             if (sp_256_iszero_9(s) == 0) {
                 break;

--- a/sp_sm2_c64.c
+++ b/sp_sm2_c64.c
@@ -5581,6 +5581,11 @@ int sp_ecc_sign_sm2_256(const byte* hash, word32 hashLen, WC_RNG* rng,
                 sp_256_mont_mul_order_sm2_5(s, s, xInv);
             sp_256_norm_5(s);
 
+            c = sp_256_cmp_sm2_5(s, p256_sm2_order);
+            sp_256_cond_sub_sm2_5(s, s, p256_sm2_order,
+                0L - (sp_digit)(c >= 0));
+            sp_256_norm_5(s);
+
             /* Check that signature is usable. */
             if (sp_256_iszero_5(s) == 0) {
                 break;

--- a/sp_sm2_cortexm.c
+++ b/sp_sm2_cortexm.c
@@ -8944,6 +8944,11 @@ int sp_ecc_sign_sm2_256(const byte* hash, word32 hashLen, WC_RNG* rng,
                 sp_256_mont_mul_order_sm2_8(s, s, xInv);
             sp_256_norm_8(s);
 
+            c = sp_256_cmp_sm2_8(s, p256_sm2_order);
+            sp_256_cond_sub_sm2_8(s, s, p256_sm2_order,
+                0L - (sp_digit)(c >= 0));
+            sp_256_norm_8(s);
+
             /* Check that signature is usable. */
             if (sp_256_iszero_8(s) == 0) {
                 break;

--- a/sp_sm2_x86_64.c
+++ b/sp_sm2_x86_64.c
@@ -17636,6 +17636,11 @@ int sp_ecc_sign_sm2_256(const byte* hash, word32 hashLen, WC_RNG* rng,
                 sp_256_mont_mul_order_sm2_4(s, s, xInv);
             sp_256_norm_4(s);
 
+            c = sp_256_cmp_sm2_4(s, p256_sm2_order);
+            sp_256_cond_sub_sm2_4(s, s, p256_sm2_order,
+                0L - (sp_digit)(c >= 0));
+            sp_256_norm_4(s);
+
             /* Check that signature is usable. */
             if (sp_256_iszero_4(s) == 0) {
                 break;

--- a/sp_sm2_x86_64_asm.S
+++ b/sp_sm2_x86_64_asm.S
@@ -1,5 +1,5 @@
-/* sp_sm2_x86_64_asm
- *
+/* sp_sm2_x86_64_asm.S */
+/*
  * Copyright (C) 2006-2023 wolfSSL Inc.
  *
  * This file is part of wolfSSL.


### PR DESCRIPTION
When signing s wasn't reduced to less than order after multiplication. Compare, conditional subtract and normalize before check of 0.