### PR TITLE
clang-tidy fixes

### DIFF
--- a/sm2.c
+++ b/sm2.c
@@ -514,7 +514,8 @@ int wc_ecc_sm2_sign_hash_ex(const byte* hash, word32 hashSz, WC_RNG* rng,
     /* Initialize MP integers needed. */
     if (err == MP_OKAY) {
         err = mp_init_multi(x, e, b, order, NULL, NULL);
-
+    }
+    if (err == MP_OKAY) {
         /* Initialize ephemeral key. */
         err = wc_ecc_init_ex(pub, key->heap, INVALID_DEVID);
         if (err == MP_OKAY) {


### PR DESCRIPTION
sm3.c:
  Put macro parameters in brackets when used.
Split SM3_ITER into two macros. One for first 12 iterations and second for remaining.
  Fix type by casting to word32 pointer.
  Explicitly include hash.h for WC_HASH_FLAG_ISCOPY.
sm2.c: Check error return code after call to mp_init_multi.