### PR TITLE
20240913-clang-tidy

### DIFF
--- a/scripts/sp/ecc_sm2.rb
+++ b/scripts/sp/ecc_sm2.rb
@@ -580,9 +580,6 @@ EOF
         /* (r - e + n*order).z'.z' mod prime == (s.G + t.Q)->x' */
         /* Load e, subtract from r. */
         sp_#{@total}_from_bin(e, #{@words}, hash, (int)hashLen);
-        if (sp_#{@total}_cmp_#{@namef}#{@words}(r, e) < 0) {
-            carry = sp_#{@total}_add_#{@namef}#{@words}(r, r, #{@cname}_order);
-        }
         sp_#{@total}_sub_#{@namef}#{@words}(e, r, e);
         sp_#{@total}_norm_#{@words}(e);
         /* x' == (r - e).z'.z' mod prime */

--- a/sm3_asm.S
+++ b/sm3_asm.S
@@ -1,6 +1,6 @@
 /* sm3_asm.S */
 /*
- * Copyright (C) 2006-2023 wolfSSL Inc.
+ * Copyright (C) 2006-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *

--- a/sm3_asm.asm
+++ b/sm3_asm.asm
@@ -1,6 +1,6 @@
 ; /* sm3_asm.asm */
 ; /*
-;  * Copyright (C) 2006-2023 wolfSSL Inc.
+;  * Copyright (C) 2006-2024 wolfSSL Inc.
 ;  *
 ;  * This file is part of wolfSSL.
 ;  *
@@ -88,13 +88,13 @@ sm3_compress_avx1 PROC
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t]
         mov	ecx, r8d
         add	edx, r12d
-        roll	ecx, 12
+        rol	ecx, 12
         vpalignr	xmm5, xmm1, xmm0, 12
         ; iter_0: 1 - 1
         mov	eax, DWORD PTR [rsp+16]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp]
-        roll	edx, 7
+        rol	edx, 7
         vpalignr	xmm4, xmm3, xmm2, 8
         ; iter_0: 2 - 2
         xor	ecx, edx
@@ -119,26 +119,26 @@ sm3_compress_avx1 PROC
         add	r15d, ecx
         add	r11d, edx
         mov	ebx, r11d
-        roll	r11d, 8
+        rol	r11d, 8
         vpalignr	xmm10, xmm2, xmm1, 12
         ; iter_0: 6 - 7
-        roll	r9d, 9
+        rol	r9d, 9
         xor	r11d, ebx
-        roll	r13d, 19
-        roll	r11d, 9
+        rol	r13d, 19
+        rol	r11d, 9
         xor	r11d, ebx
         vpxor	xmm10, xmm0, xmm10
         ; iter_1: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+8]
         mov	ecx, r15d
         add	edx, r11d
-        roll	ecx, 12
+        rol	ecx, 12
         vpshufd	xmm4, xmm3, 249
         ; iter_1: 1 - 2
         mov	eax, DWORD PTR [rsp+20]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+4]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -161,14 +161,14 @@ sm3_compress_avx1 PROC
         add	r14d, ecx
         add	r10d, edx
         mov	ebx, r10d
-        roll	r10d, 8
+        rol	r10d, 8
         vpslld	xmm8, xmm4, 15
         vpsrld	xmm7, xmm4, 17
         ; iter_1: 6 - 6
-        roll	r8d, 9
+        rol	r8d, 9
         xor	r10d, ebx
-        roll	r12d, 19
-        roll	r10d, 9
+        rol	r12d, 19
+        rol	r10d, 9
         vpslld	xmm6, xmm4, 23
         vpsrld	xmm5, xmm4, 9
         ; iter_1: 7 - 7
@@ -177,14 +177,14 @@ sm3_compress_avx1 PROC
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+16]
         mov	ecx, r14d
         add	edx, r10d
-        roll	ecx, 12
+        rol	ecx, 12
         vpor	xmm8, xmm7, xmm8
         vpor	xmm6, xmm5, xmm6
         ; iter_2: 1 - 1
         mov	eax, DWORD PTR [rsp+24]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+8]
-        roll	edx, 7
+        rol	edx, 7
         vpxor	xmm8, xmm6, xmm8
         vpxor	xmm4, xmm9, xmm4
         ; iter_2: 2 - 2
@@ -207,14 +207,14 @@ sm3_compress_avx1 PROC
         add	r13d, ecx
         add	r9d, edx
         mov	ebx, r9d
-        roll	r9d, 8
+        rol	r9d, 8
         vpslld	xmm5, xmm4, 15
         vpsrld	xmm4, xmm4, 17
         ; iter_2: 6 - 6
-        roll	r15d, 9
+        rol	r15d, 9
         xor	r9d, ebx
-        roll	r11d, 19
-        roll	r9d, 9
+        rol	r11d, 19
+        rol	r9d, 9
         vpor	xmm4, xmm5, xmm4
         ; iter_2: 7 - 7
         xor	r9d, ebx
@@ -223,14 +223,14 @@ sm3_compress_avx1 PROC
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+24]
         mov	ecx, r13d
         add	edx, r9d
-        roll	ecx, 12
+        rol	ecx, 12
         vpslld	xmm7, xmm10, 15
         vpsrld	xmm6, xmm10, 17
         ; iter_3: 1 - 1
         mov	eax, DWORD PTR [rsp+28]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+12]
-        roll	edx, 7
+        rol	edx, 7
         vpslld	xmm5, xmm10, 23
         vpsrld	xmm4, xmm10, 9
         ; iter_3: 2 - 2
@@ -257,13 +257,13 @@ sm3_compress_avx1 PROC
         add	r12d, ecx
         add	r8d, edx
         mov	ebx, r8d
-        roll	r8d, 8
+        rol	r8d, 8
         vpblendw	xmm0, xmm8, xmm10, 192
         ; iter_3: 6 - 6
-        roll	r14d, 9
+        rol	r14d, 9
         xor	r8d, ebx
-        roll	r10d, 19
-        roll	r8d, 9
+        rol	r10d, 19
+        rol	r8d, 9
         ; iter_3: 7 - 7
         xor	r8d, ebx
         ; msg_sched done: 0-3
@@ -272,13 +272,13 @@ sm3_compress_avx1 PROC
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+32]
         mov	ecx, r12d
         add	edx, r8d
-        roll	ecx, 12
+        rol	ecx, 12
         vpalignr	xmm5, xmm2, xmm1, 12
         ; iter_4: 1 - 1
         mov	eax, DWORD PTR [rsp+32]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+16]
-        roll	edx, 7
+        rol	edx, 7
         vpalignr	xmm4, xmm0, xmm3, 8
         ; iter_4: 2 - 2
         xor	ecx, edx
@@ -303,26 +303,26 @@ sm3_compress_avx1 PROC
         add	r11d, ecx
         add	r15d, edx
         mov	ebx, r15d
-        roll	r15d, 8
+        rol	r15d, 8
         vpalignr	xmm10, xmm3, xmm2, 12
         ; iter_4: 6 - 7
-        roll	r13d, 9
+        rol	r13d, 9
         xor	r15d, ebx
-        roll	r9d, 19
-        roll	r15d, 9
+        rol	r9d, 19
+        rol	r15d, 9
         xor	r15d, ebx
         vpxor	xmm10, xmm1, xmm10
         ; iter_5: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+40]
         mov	ecx, r11d
         add	edx, r15d
-        roll	ecx, 12
+        rol	ecx, 12
         vpshufd	xmm4, xmm0, 249
         ; iter_5: 1 - 2
         mov	eax, DWORD PTR [rsp+36]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+20]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -345,14 +345,14 @@ sm3_compress_avx1 PROC
         add	r10d, ecx
         add	r14d, edx
         mov	ebx, r14d
-        roll	r14d, 8
+        rol	r14d, 8
         vpslld	xmm8, xmm4, 15
         vpsrld	xmm7, xmm4, 17
         ; iter_5: 6 - 6
-        roll	r12d, 9
+        rol	r12d, 9
         xor	r14d, ebx
-        roll	r8d, 19
-        roll	r14d, 9
+        rol	r8d, 19
+        rol	r14d, 9
         vpslld	xmm6, xmm4, 23
         vpsrld	xmm5, xmm4, 9
         ; iter_5: 7 - 7
@@ -361,14 +361,14 @@ sm3_compress_avx1 PROC
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+48]
         mov	ecx, r10d
         add	edx, r14d
-        roll	ecx, 12
+        rol	ecx, 12
         vpor	xmm8, xmm7, xmm8
         vpor	xmm6, xmm5, xmm6
         ; iter_6: 1 - 1
         mov	eax, DWORD PTR [rsp+40]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+24]
-        roll	edx, 7
+        rol	edx, 7
         vpxor	xmm8, xmm6, xmm8
         vpxor	xmm4, xmm9, xmm4
         ; iter_6: 2 - 2
@@ -391,14 +391,14 @@ sm3_compress_avx1 PROC
         add	r9d, ecx
         add	r13d, edx
         mov	ebx, r13d
-        roll	r13d, 8
+        rol	r13d, 8
         vpslld	xmm5, xmm4, 15
         vpsrld	xmm4, xmm4, 17
         ; iter_6: 6 - 6
-        roll	r11d, 9
+        rol	r11d, 9
         xor	r13d, ebx
-        roll	r15d, 19
-        roll	r13d, 9
+        rol	r15d, 19
+        rol	r13d, 9
         vpor	xmm4, xmm5, xmm4
         ; iter_6: 7 - 7
         xor	r13d, ebx
@@ -407,14 +407,14 @@ sm3_compress_avx1 PROC
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+56]
         mov	ecx, r9d
         add	edx, r13d
-        roll	ecx, 12
+        rol	ecx, 12
         vpslld	xmm7, xmm10, 15
         vpsrld	xmm6, xmm10, 17
         ; iter_7: 1 - 1
         mov	eax, DWORD PTR [rsp+44]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+28]
-        roll	edx, 7
+        rol	edx, 7
         vpslld	xmm5, xmm10, 23
         vpsrld	xmm4, xmm10, 9
         ; iter_7: 2 - 2
@@ -441,13 +441,13 @@ sm3_compress_avx1 PROC
         add	r8d, ecx
         add	r12d, edx
         mov	ebx, r12d
-        roll	r12d, 8
+        rol	r12d, 8
         vpblendw	xmm1, xmm8, xmm10, 192
         ; iter_7: 6 - 6
-        roll	r10d, 9
+        rol	r10d, 9
         xor	r12d, ebx
-        roll	r14d, 19
-        roll	r12d, 9
+        rol	r14d, 19
+        rol	r12d, 9
         ; iter_7: 7 - 7
         xor	r12d, ebx
         ; msg_sched done: 4-7
@@ -459,13 +459,13 @@ sm3_compress_avx1 PROC
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+64]
         mov	ecx, r8d
         add	edx, r12d
-        roll	ecx, 12
+        rol	ecx, 12
         vpalignr	xmm5, xmm3, xmm2, 12
         ; iter_8: 1 - 1
         mov	eax, DWORD PTR [rsp+48]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+32]
-        roll	edx, 7
+        rol	edx, 7
         vpalignr	xmm4, xmm1, xmm0, 8
         ; iter_8: 2 - 2
         xor	ecx, edx
@@ -490,26 +490,26 @@ sm3_compress_avx1 PROC
         add	r15d, ecx
         add	r11d, edx
         mov	ebx, r11d
-        roll	r11d, 8
+        rol	r11d, 8
         vpalignr	xmm10, xmm0, xmm3, 12
         ; iter_8: 6 - 7
-        roll	r9d, 9
+        rol	r9d, 9
         xor	r11d, ebx
-        roll	r13d, 19
-        roll	r11d, 9
+        rol	r13d, 19
+        rol	r11d, 9
         xor	r11d, ebx
         vpxor	xmm10, xmm2, xmm10
         ; iter_9: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+72]
         mov	ecx, r15d
         add	edx, r11d
-        roll	ecx, 12
+        rol	ecx, 12
         vpshufd	xmm4, xmm1, 249
         ; iter_9: 1 - 2
         mov	eax, DWORD PTR [rsp+52]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+36]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -532,14 +532,14 @@ sm3_compress_avx1 PROC
         add	r14d, ecx
         add	r10d, edx
         mov	ebx, r10d
-        roll	r10d, 8
+        rol	r10d, 8
         vpslld	xmm8, xmm4, 15
         vpsrld	xmm7, xmm4, 17
         ; iter_9: 6 - 6
-        roll	r8d, 9
+        rol	r8d, 9
         xor	r10d, ebx
-        roll	r12d, 19
-        roll	r10d, 9
+        rol	r12d, 19
+        rol	r10d, 9
         vpslld	xmm6, xmm4, 23
         vpsrld	xmm5, xmm4, 9
         ; iter_9: 7 - 7
@@ -548,14 +548,14 @@ sm3_compress_avx1 PROC
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+80]
         mov	ecx, r14d
         add	edx, r10d
-        roll	ecx, 12
+        rol	ecx, 12
         vpor	xmm8, xmm7, xmm8
         vpor	xmm6, xmm5, xmm6
         ; iter_10: 1 - 1
         mov	eax, DWORD PTR [rsp+56]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+40]
-        roll	edx, 7
+        rol	edx, 7
         vpxor	xmm8, xmm6, xmm8
         vpxor	xmm4, xmm9, xmm4
         ; iter_10: 2 - 2
@@ -578,14 +578,14 @@ sm3_compress_avx1 PROC
         add	r13d, ecx
         add	r9d, edx
         mov	ebx, r9d
-        roll	r9d, 8
+        rol	r9d, 8
         vpslld	xmm5, xmm4, 15
         vpsrld	xmm4, xmm4, 17
         ; iter_10: 6 - 6
-        roll	r15d, 9
+        rol	r15d, 9
         xor	r9d, ebx
-        roll	r11d, 19
-        roll	r9d, 9
+        rol	r11d, 19
+        rol	r9d, 9
         vpor	xmm4, xmm5, xmm4
         ; iter_10: 7 - 7
         xor	r9d, ebx
@@ -594,14 +594,14 @@ sm3_compress_avx1 PROC
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+88]
         mov	ecx, r13d
         add	edx, r9d
-        roll	ecx, 12
+        rol	ecx, 12
         vpslld	xmm7, xmm10, 15
         vpsrld	xmm6, xmm10, 17
         ; iter_11: 1 - 1
         mov	eax, DWORD PTR [rsp+60]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+44]
-        roll	edx, 7
+        rol	edx, 7
         vpslld	xmm5, xmm10, 23
         vpsrld	xmm4, xmm10, 9
         ; iter_11: 2 - 2
@@ -628,13 +628,13 @@ sm3_compress_avx1 PROC
         add	r12d, ecx
         add	r8d, edx
         mov	ebx, r8d
-        roll	r8d, 8
+        rol	r8d, 8
         vpblendw	xmm2, xmm8, xmm10, 192
         ; iter_11: 6 - 6
-        roll	r14d, 9
+        rol	r14d, 9
         xor	r8d, ebx
-        roll	r10d, 19
-        roll	r8d, 9
+        rol	r10d, 19
+        rol	r8d, 9
         ; iter_11: 7 - 7
         xor	r8d, ebx
         ; msg_sched done: 8-11
@@ -643,13 +643,13 @@ sm3_compress_avx1 PROC
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+96]
         mov	ecx, r12d
         add	edx, r8d
-        roll	ecx, 12
+        rol	ecx, 12
         vpalignr	xmm5, xmm0, xmm3, 12
         ; iter_12: 1 - 1
         mov	eax, DWORD PTR [rsp+64]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+48]
-        roll	edx, 7
+        rol	edx, 7
         vpalignr	xmm4, xmm2, xmm1, 8
         ; iter_12: 2 - 2
         xor	ecx, edx
@@ -674,26 +674,26 @@ sm3_compress_avx1 PROC
         add	r11d, ecx
         add	r15d, edx
         mov	ebx, r15d
-        roll	r15d, 8
+        rol	r15d, 8
         vpalignr	xmm10, xmm1, xmm0, 12
         ; iter_12: 6 - 7
-        roll	r13d, 9
+        rol	r13d, 9
         xor	r15d, ebx
-        roll	r9d, 19
-        roll	r15d, 9
+        rol	r9d, 19
+        rol	r15d, 9
         xor	r15d, ebx
         vpxor	xmm10, xmm3, xmm10
         ; iter_13: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+104]
         mov	ecx, r11d
         add	edx, r15d
-        roll	ecx, 12
+        rol	ecx, 12
         vpshufd	xmm4, xmm2, 249
         ; iter_13: 1 - 2
         mov	eax, DWORD PTR [rsp+68]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+52]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -716,14 +716,14 @@ sm3_compress_avx1 PROC
         add	r10d, ecx
         add	r14d, edx
         mov	ebx, r14d
-        roll	r14d, 8
+        rol	r14d, 8
         vpslld	xmm8, xmm4, 15
         vpsrld	xmm7, xmm4, 17
         ; iter_13: 6 - 6
-        roll	r12d, 9
+        rol	r12d, 9
         xor	r14d, ebx
-        roll	r8d, 19
-        roll	r14d, 9
+        rol	r8d, 19
+        rol	r14d, 9
         vpslld	xmm6, xmm4, 23
         vpsrld	xmm5, xmm4, 9
         ; iter_13: 7 - 7
@@ -732,14 +732,14 @@ sm3_compress_avx1 PROC
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+112]
         mov	ecx, r10d
         add	edx, r14d
-        roll	ecx, 12
+        rol	ecx, 12
         vpor	xmm8, xmm7, xmm8
         vpor	xmm6, xmm5, xmm6
         ; iter_14: 1 - 1
         mov	eax, DWORD PTR [rsp+72]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+56]
-        roll	edx, 7
+        rol	edx, 7
         vpxor	xmm8, xmm6, xmm8
         vpxor	xmm4, xmm9, xmm4
         ; iter_14: 2 - 2
@@ -762,14 +762,14 @@ sm3_compress_avx1 PROC
         add	r9d, ecx
         add	r13d, edx
         mov	ebx, r13d
-        roll	r13d, 8
+        rol	r13d, 8
         vpslld	xmm5, xmm4, 15
         vpsrld	xmm4, xmm4, 17
         ; iter_14: 6 - 6
-        roll	r11d, 9
+        rol	r11d, 9
         xor	r13d, ebx
-        roll	r15d, 19
-        roll	r13d, 9
+        rol	r15d, 19
+        rol	r13d, 9
         vpor	xmm4, xmm5, xmm4
         ; iter_14: 7 - 7
         xor	r13d, ebx
@@ -778,14 +778,14 @@ sm3_compress_avx1 PROC
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+120]
         mov	ecx, r9d
         add	edx, r13d
-        roll	ecx, 12
+        rol	ecx, 12
         vpslld	xmm7, xmm10, 15
         vpsrld	xmm6, xmm10, 17
         ; iter_15: 1 - 1
         mov	eax, DWORD PTR [rsp+76]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+60]
-        roll	edx, 7
+        rol	edx, 7
         vpslld	xmm5, xmm10, 23
         vpsrld	xmm4, xmm10, 9
         ; iter_15: 2 - 2
@@ -812,13 +812,13 @@ sm3_compress_avx1 PROC
         add	r8d, ecx
         add	r12d, edx
         mov	ebx, r12d
-        roll	r12d, 8
+        rol	r12d, 8
         vpblendw	xmm3, xmm8, xmm10, 192
         ; iter_15: 6 - 6
-        roll	r10d, 9
+        rol	r10d, 9
         xor	r12d, ebx
-        roll	r14d, 19
-        roll	r12d, 9
+        rol	r14d, 19
+        rol	r12d, 9
         ; iter_15: 7 - 7
         xor	r12d, ebx
         ; msg_sched done: 12-15
@@ -830,13 +830,13 @@ sm3_compress_avx1 PROC
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+128]
         mov	ecx, r8d
         add	edx, r12d
-        roll	ecx, 12
+        rol	ecx, 12
         vpalignr	xmm5, xmm1, xmm0, 12
         ; iter_16: 1 - 1
         mov	eax, DWORD PTR [rsp+80]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+64]
-        roll	edx, 7
+        rol	edx, 7
         vpalignr	xmm4, xmm3, xmm2, 8
         ; iter_16: 2 - 2
         xor	ecx, edx
@@ -867,24 +867,24 @@ sm3_compress_avx1 PROC
         add	r15d, ecx
         add	r11d, edx
         mov	ebx, r11d
-        roll	r11d, 8
-        roll	r9d, 9
+        rol	r11d, 8
+        rol	r9d, 9
         xor	r11d, ebx
-        roll	r13d, 19
-        roll	r11d, 9
+        rol	r13d, 19
+        rol	r11d, 9
         xor	r11d, ebx
         vpxor	xmm10, xmm0, xmm10
         ; iter_17: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+136]
         mov	ecx, r15d
         add	edx, r11d
-        roll	ecx, 12
+        rol	ecx, 12
         vpshufd	xmm4, xmm3, 249
         ; iter_17: 1 - 2
         mov	eax, DWORD PTR [rsp+84]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+68]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -914,27 +914,27 @@ sm3_compress_avx1 PROC
         add	r14d, ecx
         add	r10d, edx
         mov	ebx, r10d
-        roll	r10d, 8
+        rol	r10d, 8
         vpslld	xmm6, xmm4, 23
         vpsrld	xmm5, xmm4, 9
         ; iter_17: 7 - 7
-        roll	r8d, 9
+        rol	r8d, 9
         xor	r10d, ebx
-        roll	r12d, 19
-        roll	r10d, 9
+        rol	r12d, 19
+        rol	r10d, 9
         xor	r10d, ebx
         ; iter_18: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+144]
         mov	ecx, r14d
         add	edx, r10d
-        roll	ecx, 12
+        rol	ecx, 12
         vpor	xmm8, xmm7, xmm8
         vpor	xmm6, xmm5, xmm6
         ; iter_18: 1 - 1
         mov	eax, DWORD PTR [rsp+88]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+72]
-        roll	edx, 7
+        rol	edx, 7
         vpxor	xmm8, xmm6, xmm8
         vpxor	xmm4, xmm9, xmm4
         ; iter_18: 2 - 2
@@ -964,27 +964,27 @@ sm3_compress_avx1 PROC
         add	r13d, ecx
         add	r9d, edx
         mov	ebx, r9d
-        roll	r9d, 8
+        rol	r9d, 8
         vpor	xmm4, xmm5, xmm4
         ; iter_18: 7 - 7
-        roll	r15d, 9
+        rol	r15d, 9
         xor	r9d, ebx
-        roll	r11d, 19
-        roll	r9d, 9
+        rol	r11d, 19
+        rol	r9d, 9
         xor	r9d, ebx
         vpxor	xmm10, xmm4, xmm10
         ; iter_19: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+152]
         mov	ecx, r13d
         add	edx, r9d
-        roll	ecx, 12
+        rol	ecx, 12
         vpslld	xmm7, xmm10, 15
         vpsrld	xmm6, xmm10, 17
         ; iter_19: 1 - 1
         mov	eax, DWORD PTR [rsp+92]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+76]
-        roll	edx, 7
+        rol	edx, 7
         vpslld	xmm5, xmm10, 23
         vpsrld	xmm4, xmm10, 9
         ; iter_19: 2 - 2
@@ -1017,12 +1017,12 @@ sm3_compress_avx1 PROC
         add	r12d, ecx
         add	r8d, edx
         mov	ebx, r8d
-        roll	r8d, 8
+        rol	r8d, 8
         ; iter_19: 7 - 7
-        roll	r14d, 9
+        rol	r14d, 9
         xor	r8d, ebx
-        roll	r10d, 19
-        roll	r8d, 9
+        rol	r10d, 19
+        rol	r8d, 9
         xor	r8d, ebx
         ; msg_sched done: 16-19
         ; msg_sched: 20-23
@@ -1030,13 +1030,13 @@ sm3_compress_avx1 PROC
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+160]
         mov	ecx, r12d
         add	edx, r8d
-        roll	ecx, 12
+        rol	ecx, 12
         vpalignr	xmm5, xmm2, xmm1, 12
         ; iter_20: 1 - 1
         mov	eax, DWORD PTR [rsp+96]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+80]
-        roll	edx, 7
+        rol	edx, 7
         vpalignr	xmm4, xmm0, xmm3, 8
         ; iter_20: 2 - 2
         xor	ecx, edx
@@ -1067,24 +1067,24 @@ sm3_compress_avx1 PROC
         add	r11d, ecx
         add	r15d, edx
         mov	ebx, r15d
-        roll	r15d, 8
-        roll	r13d, 9
+        rol	r15d, 8
+        rol	r13d, 9
         xor	r15d, ebx
-        roll	r9d, 19
-        roll	r15d, 9
+        rol	r9d, 19
+        rol	r15d, 9
         xor	r15d, ebx
         vpxor	xmm10, xmm1, xmm10
         ; iter_21: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+168]
         mov	ecx, r11d
         add	edx, r15d
-        roll	ecx, 12
+        rol	ecx, 12
         vpshufd	xmm4, xmm0, 249
         ; iter_21: 1 - 2
         mov	eax, DWORD PTR [rsp+100]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+84]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -1114,27 +1114,27 @@ sm3_compress_avx1 PROC
         add	r10d, ecx
         add	r14d, edx
         mov	ebx, r14d
-        roll	r14d, 8
+        rol	r14d, 8
         vpslld	xmm6, xmm4, 23
         vpsrld	xmm5, xmm4, 9
         ; iter_21: 7 - 7
-        roll	r12d, 9
+        rol	r12d, 9
         xor	r14d, ebx
-        roll	r8d, 19
-        roll	r14d, 9
+        rol	r8d, 19
+        rol	r14d, 9
         xor	r14d, ebx
         ; iter_22: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+176]
         mov	ecx, r10d
         add	edx, r14d
-        roll	ecx, 12
+        rol	ecx, 12
         vpor	xmm8, xmm7, xmm8
         vpor	xmm6, xmm5, xmm6
         ; iter_22: 1 - 1
         mov	eax, DWORD PTR [rsp+104]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+88]
-        roll	edx, 7
+        rol	edx, 7
         vpxor	xmm8, xmm6, xmm8
         vpxor	xmm4, xmm9, xmm4
         ; iter_22: 2 - 2
@@ -1164,27 +1164,27 @@ sm3_compress_avx1 PROC
         add	r9d, ecx
         add	r13d, edx
         mov	ebx, r13d
-        roll	r13d, 8
+        rol	r13d, 8
         vpor	xmm4, xmm5, xmm4
         ; iter_22: 7 - 7
-        roll	r11d, 9
+        rol	r11d, 9
         xor	r13d, ebx
-        roll	r15d, 19
-        roll	r13d, 9
+        rol	r15d, 19
+        rol	r13d, 9
         xor	r13d, ebx
         vpxor	xmm10, xmm4, xmm10
         ; iter_23: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+184]
         mov	ecx, r9d
         add	edx, r13d
-        roll	ecx, 12
+        rol	ecx, 12
         vpslld	xmm7, xmm10, 15
         vpsrld	xmm6, xmm10, 17
         ; iter_23: 1 - 1
         mov	eax, DWORD PTR [rsp+108]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+92]
-        roll	edx, 7
+        rol	edx, 7
         vpslld	xmm5, xmm10, 23
         vpsrld	xmm4, xmm10, 9
         ; iter_23: 2 - 2
@@ -1217,12 +1217,12 @@ sm3_compress_avx1 PROC
         add	r8d, ecx
         add	r12d, edx
         mov	ebx, r12d
-        roll	r12d, 8
+        rol	r12d, 8
         ; iter_23: 7 - 7
-        roll	r10d, 9
+        rol	r10d, 9
         xor	r12d, ebx
-        roll	r14d, 19
-        roll	r12d, 9
+        rol	r14d, 19
+        rol	r12d, 9
         xor	r12d, ebx
         ; msg_sched done: 20-23
         ; x2_to_w: 32
@@ -1233,13 +1233,13 @@ sm3_compress_avx1 PROC
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+192]
         mov	ecx, r8d
         add	edx, r12d
-        roll	ecx, 12
+        rol	ecx, 12
         vpalignr	xmm5, xmm3, xmm2, 12
         ; iter_24: 1 - 1
         mov	eax, DWORD PTR [rsp+112]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+96]
-        roll	edx, 7
+        rol	edx, 7
         vpalignr	xmm4, xmm1, xmm0, 8
         ; iter_24: 2 - 2
         xor	ecx, edx
@@ -1270,24 +1270,24 @@ sm3_compress_avx1 PROC
         add	r15d, ecx
         add	r11d, edx
         mov	ebx, r11d
-        roll	r11d, 8
-        roll	r9d, 9
+        rol	r11d, 8
+        rol	r9d, 9
         xor	r11d, ebx
-        roll	r13d, 19
-        roll	r11d, 9
+        rol	r13d, 19
+        rol	r11d, 9
         xor	r11d, ebx
         vpxor	xmm10, xmm2, xmm10
         ; iter_25: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+200]
         mov	ecx, r15d
         add	edx, r11d
-        roll	ecx, 12
+        rol	ecx, 12
         vpshufd	xmm4, xmm1, 249
         ; iter_25: 1 - 2
         mov	eax, DWORD PTR [rsp+116]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+100]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -1317,27 +1317,27 @@ sm3_compress_avx1 PROC
         add	r14d, ecx
         add	r10d, edx
         mov	ebx, r10d
-        roll	r10d, 8
+        rol	r10d, 8
         vpslld	xmm6, xmm4, 23
         vpsrld	xmm5, xmm4, 9
         ; iter_25: 7 - 7
-        roll	r8d, 9
+        rol	r8d, 9
         xor	r10d, ebx
-        roll	r12d, 19
-        roll	r10d, 9
+        rol	r12d, 19
+        rol	r10d, 9
         xor	r10d, ebx
         ; iter_26: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+208]
         mov	ecx, r14d
         add	edx, r10d
-        roll	ecx, 12
+        rol	ecx, 12
         vpor	xmm8, xmm7, xmm8
         vpor	xmm6, xmm5, xmm6
         ; iter_26: 1 - 1
         mov	eax, DWORD PTR [rsp+120]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+104]
-        roll	edx, 7
+        rol	edx, 7
         vpxor	xmm8, xmm6, xmm8
         vpxor	xmm4, xmm9, xmm4
         ; iter_26: 2 - 2
@@ -1367,27 +1367,27 @@ sm3_compress_avx1 PROC
         add	r13d, ecx
         add	r9d, edx
         mov	ebx, r9d
-        roll	r9d, 8
+        rol	r9d, 8
         vpor	xmm4, xmm5, xmm4
         ; iter_26: 7 - 7
-        roll	r15d, 9
+        rol	r15d, 9
         xor	r9d, ebx
-        roll	r11d, 19
-        roll	r9d, 9
+        rol	r11d, 19
+        rol	r9d, 9
         xor	r9d, ebx
         vpxor	xmm10, xmm4, xmm10
         ; iter_27: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+216]
         mov	ecx, r13d
         add	edx, r9d
-        roll	ecx, 12
+        rol	ecx, 12
         vpslld	xmm7, xmm10, 15
         vpsrld	xmm6, xmm10, 17
         ; iter_27: 1 - 1
         mov	eax, DWORD PTR [rsp+124]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+108]
-        roll	edx, 7
+        rol	edx, 7
         vpslld	xmm5, xmm10, 23
         vpsrld	xmm4, xmm10, 9
         ; iter_27: 2 - 2
@@ -1420,12 +1420,12 @@ sm3_compress_avx1 PROC
         add	r12d, ecx
         add	r8d, edx
         mov	ebx, r8d
-        roll	r8d, 8
+        rol	r8d, 8
         ; iter_27: 7 - 7
-        roll	r14d, 9
+        rol	r14d, 9
         xor	r8d, ebx
-        roll	r10d, 19
-        roll	r8d, 9
+        rol	r10d, 19
+        rol	r8d, 9
         xor	r8d, ebx
         ; msg_sched done: 24-27
         ; msg_sched: 28-31
@@ -1433,13 +1433,13 @@ sm3_compress_avx1 PROC
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+224]
         mov	ecx, r12d
         add	edx, r8d
-        roll	ecx, 12
+        rol	ecx, 12
         vpalignr	xmm5, xmm0, xmm3, 12
         ; iter_28: 1 - 1
         mov	eax, DWORD PTR [rsp+128]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+112]
-        roll	edx, 7
+        rol	edx, 7
         vpalignr	xmm4, xmm2, xmm1, 8
         ; iter_28: 2 - 2
         xor	ecx, edx
@@ -1470,24 +1470,24 @@ sm3_compress_avx1 PROC
         add	r11d, ecx
         add	r15d, edx
         mov	ebx, r15d
-        roll	r15d, 8
-        roll	r13d, 9
+        rol	r15d, 8
+        rol	r13d, 9
         xor	r15d, ebx
-        roll	r9d, 19
-        roll	r15d, 9
+        rol	r9d, 19
+        rol	r15d, 9
         xor	r15d, ebx
         vpxor	xmm10, xmm3, xmm10
         ; iter_29: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+232]
         mov	ecx, r11d
         add	edx, r15d
-        roll	ecx, 12
+        rol	ecx, 12
         vpshufd	xmm4, xmm2, 249
         ; iter_29: 1 - 2
         mov	eax, DWORD PTR [rsp+132]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+116]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -1517,27 +1517,27 @@ sm3_compress_avx1 PROC
         add	r10d, ecx
         add	r14d, edx
         mov	ebx, r14d
-        roll	r14d, 8
+        rol	r14d, 8
         vpslld	xmm6, xmm4, 23
         vpsrld	xmm5, xmm4, 9
         ; iter_29: 7 - 7
-        roll	r12d, 9
+        rol	r12d, 9
         xor	r14d, ebx
-        roll	r8d, 19
-        roll	r14d, 9
+        rol	r8d, 19
+        rol	r14d, 9
         xor	r14d, ebx
         ; iter_30: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+240]
         mov	ecx, r10d
         add	edx, r14d
-        roll	ecx, 12
+        rol	ecx, 12
         vpor	xmm8, xmm7, xmm8
         vpor	xmm6, xmm5, xmm6
         ; iter_30: 1 - 1
         mov	eax, DWORD PTR [rsp+136]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+120]
-        roll	edx, 7
+        rol	edx, 7
         vpxor	xmm8, xmm6, xmm8
         vpxor	xmm4, xmm9, xmm4
         ; iter_30: 2 - 2
@@ -1567,27 +1567,27 @@ sm3_compress_avx1 PROC
         add	r9d, ecx
         add	r13d, edx
         mov	ebx, r13d
-        roll	r13d, 8
+        rol	r13d, 8
         vpor	xmm4, xmm5, xmm4
         ; iter_30: 7 - 7
-        roll	r11d, 9
+        rol	r11d, 9
         xor	r13d, ebx
-        roll	r15d, 19
-        roll	r13d, 9
+        rol	r15d, 19
+        rol	r13d, 9
         xor	r13d, ebx
         vpxor	xmm10, xmm4, xmm10
         ; iter_31: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+248]
         mov	ecx, r9d
         add	edx, r13d
-        roll	ecx, 12
+        rol	ecx, 12
         vpslld	xmm7, xmm10, 15
         vpsrld	xmm6, xmm10, 17
         ; iter_31: 1 - 1
         mov	eax, DWORD PTR [rsp+140]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+124]
-        roll	edx, 7
+        rol	edx, 7
         vpslld	xmm5, xmm10, 23
         vpsrld	xmm4, xmm10, 9
         ; iter_31: 2 - 2
@@ -1620,12 +1620,12 @@ sm3_compress_avx1 PROC
         add	r8d, ecx
         add	r12d, edx
         mov	ebx, r12d
-        roll	r12d, 8
+        rol	r12d, 8
         ; iter_31: 7 - 7
-        roll	r10d, 9
+        rol	r10d, 9
         xor	r12d, ebx
-        roll	r14d, 19
-        roll	r12d, 9
+        rol	r14d, 19
+        rol	r12d, 9
         xor	r12d, ebx
         ; msg_sched done: 28-31
         ; x2_to_w: 40
@@ -1636,13 +1636,13 @@ sm3_compress_avx1 PROC
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+256]
         mov	ecx, r8d
         add	edx, r12d
-        roll	ecx, 12
+        rol	ecx, 12
         vpalignr	xmm5, xmm1, xmm0, 12
         ; iter_32: 1 - 1
         mov	eax, DWORD PTR [rsp+144]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+128]
-        roll	edx, 7
+        rol	edx, 7
         vpalignr	xmm4, xmm3, xmm2, 8
         ; iter_32: 2 - 2
         xor	ecx, edx
@@ -1673,24 +1673,24 @@ sm3_compress_avx1 PROC
         add	r15d, ecx
         add	r11d, edx
         mov	ebx, r11d
-        roll	r11d, 8
-        roll	r9d, 9
+        rol	r11d, 8
+        rol	r9d, 9
         xor	r11d, ebx
-        roll	r13d, 19
-        roll	r11d, 9
+        rol	r13d, 19
+        rol	r11d, 9
         xor	r11d, ebx
         vpxor	xmm10, xmm0, xmm10
         ; iter_33: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+264]
         mov	ecx, r15d
         add	edx, r11d
-        roll	ecx, 12
+        rol	ecx, 12
         vpshufd	xmm4, xmm3, 249
         ; iter_33: 1 - 2
         mov	eax, DWORD PTR [rsp+148]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+132]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -1720,27 +1720,27 @@ sm3_compress_avx1 PROC
         add	r14d, ecx
         add	r10d, edx
         mov	ebx, r10d
-        roll	r10d, 8
+        rol	r10d, 8
         vpslld	xmm6, xmm4, 23
         vpsrld	xmm5, xmm4, 9
         ; iter_33: 7 - 7
-        roll	r8d, 9
+        rol	r8d, 9
         xor	r10d, ebx
-        roll	r12d, 19
-        roll	r10d, 9
+        rol	r12d, 19
+        rol	r10d, 9
         xor	r10d, ebx
         ; iter_34: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+272]
         mov	ecx, r14d
         add	edx, r10d
-        roll	ecx, 12
+        rol	ecx, 12
         vpor	xmm8, xmm7, xmm8
         vpor	xmm6, xmm5, xmm6
         ; iter_34: 1 - 1
         mov	eax, DWORD PTR [rsp+152]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+136]
-        roll	edx, 7
+        rol	edx, 7
         vpxor	xmm8, xmm6, xmm8
         vpxor	xmm4, xmm9, xmm4
         ; iter_34: 2 - 2
@@ -1770,27 +1770,27 @@ sm3_compress_avx1 PROC
         add	r13d, ecx
         add	r9d, edx
         mov	ebx, r9d
-        roll	r9d, 8
+        rol	r9d, 8
         vpor	xmm4, xmm5, xmm4
         ; iter_34: 7 - 7
-        roll	r15d, 9
+        rol	r15d, 9
         xor	r9d, ebx
-        roll	r11d, 19
-        roll	r9d, 9
+        rol	r11d, 19
+        rol	r9d, 9
         xor	r9d, ebx
         vpxor	xmm10, xmm4, xmm10
         ; iter_35: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+280]
         mov	ecx, r13d
         add	edx, r9d
-        roll	ecx, 12
+        rol	ecx, 12
         vpslld	xmm7, xmm10, 15
         vpsrld	xmm6, xmm10, 17
         ; iter_35: 1 - 1
         mov	eax, DWORD PTR [rsp+156]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+140]
-        roll	edx, 7
+        rol	edx, 7
         vpslld	xmm5, xmm10, 23
         vpsrld	xmm4, xmm10, 9
         ; iter_35: 2 - 2
@@ -1823,12 +1823,12 @@ sm3_compress_avx1 PROC
         add	r12d, ecx
         add	r8d, edx
         mov	ebx, r8d
-        roll	r8d, 8
+        rol	r8d, 8
         ; iter_35: 7 - 7
-        roll	r14d, 9
+        rol	r14d, 9
         xor	r8d, ebx
-        roll	r10d, 19
-        roll	r8d, 9
+        rol	r10d, 19
+        rol	r8d, 9
         xor	r8d, ebx
         ; msg_sched done: 32-35
         ; msg_sched: 36-39
@@ -1836,13 +1836,13 @@ sm3_compress_avx1 PROC
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+288]
         mov	ecx, r12d
         add	edx, r8d
-        roll	ecx, 12
+        rol	ecx, 12
         vpalignr	xmm5, xmm2, xmm1, 12
         ; iter_36: 1 - 1
         mov	eax, DWORD PTR [rsp+160]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+144]
-        roll	edx, 7
+        rol	edx, 7
         vpalignr	xmm4, xmm0, xmm3, 8
         ; iter_36: 2 - 2
         xor	ecx, edx
@@ -1873,24 +1873,24 @@ sm3_compress_avx1 PROC
         add	r11d, ecx
         add	r15d, edx
         mov	ebx, r15d
-        roll	r15d, 8
-        roll	r13d, 9
+        rol	r15d, 8
+        rol	r13d, 9
         xor	r15d, ebx
-        roll	r9d, 19
-        roll	r15d, 9
+        rol	r9d, 19
+        rol	r15d, 9
         xor	r15d, ebx
         vpxor	xmm10, xmm1, xmm10
         ; iter_37: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+296]
         mov	ecx, r11d
         add	edx, r15d
-        roll	ecx, 12
+        rol	ecx, 12
         vpshufd	xmm4, xmm0, 249
         ; iter_37: 1 - 2
         mov	eax, DWORD PTR [rsp+164]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+148]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -1920,27 +1920,27 @@ sm3_compress_avx1 PROC
         add	r10d, ecx
         add	r14d, edx
         mov	ebx, r14d
-        roll	r14d, 8
+        rol	r14d, 8
         vpslld	xmm6, xmm4, 23
         vpsrld	xmm5, xmm4, 9
         ; iter_37: 7 - 7
-        roll	r12d, 9
+        rol	r12d, 9
         xor	r14d, ebx
-        roll	r8d, 19
-        roll	r14d, 9
+        rol	r8d, 19
+        rol	r14d, 9
         xor	r14d, ebx
         ; iter_38: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+304]
         mov	ecx, r10d
         add	edx, r14d
-        roll	ecx, 12
+        rol	ecx, 12
         vpor	xmm8, xmm7, xmm8
         vpor	xmm6, xmm5, xmm6
         ; iter_38: 1 - 1
         mov	eax, DWORD PTR [rsp+168]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+152]
-        roll	edx, 7
+        rol	edx, 7
         vpxor	xmm8, xmm6, xmm8
         vpxor	xmm4, xmm9, xmm4
         ; iter_38: 2 - 2
@@ -1970,27 +1970,27 @@ sm3_compress_avx1 PROC
         add	r9d, ecx
         add	r13d, edx
         mov	ebx, r13d
-        roll	r13d, 8
+        rol	r13d, 8
         vpor	xmm4, xmm5, xmm4
         ; iter_38: 7 - 7
-        roll	r11d, 9
+        rol	r11d, 9
         xor	r13d, ebx
-        roll	r15d, 19
-        roll	r13d, 9
+        rol	r15d, 19
+        rol	r13d, 9
         xor	r13d, ebx
         vpxor	xmm10, xmm4, xmm10
         ; iter_39: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+312]
         mov	ecx, r9d
         add	edx, r13d
-        roll	ecx, 12
+        rol	ecx, 12
         vpslld	xmm7, xmm10, 15
         vpsrld	xmm6, xmm10, 17
         ; iter_39: 1 - 1
         mov	eax, DWORD PTR [rsp+172]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+156]
-        roll	edx, 7
+        rol	edx, 7
         vpslld	xmm5, xmm10, 23
         vpsrld	xmm4, xmm10, 9
         ; iter_39: 2 - 2
@@ -2023,12 +2023,12 @@ sm3_compress_avx1 PROC
         add	r8d, ecx
         add	r12d, edx
         mov	ebx, r12d
-        roll	r12d, 8
+        rol	r12d, 8
         ; iter_39: 7 - 7
-        roll	r10d, 9
+        rol	r10d, 9
         xor	r12d, ebx
-        roll	r14d, 19
-        roll	r12d, 9
+        rol	r14d, 19
+        rol	r12d, 9
         xor	r12d, ebx
         ; msg_sched done: 36-39
         ; x2_to_w: 48
@@ -2039,13 +2039,13 @@ sm3_compress_avx1 PROC
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+320]
         mov	ecx, r8d
         add	edx, r12d
-        roll	ecx, 12
+        rol	ecx, 12
         vpalignr	xmm5, xmm3, xmm2, 12
         ; iter_40: 1 - 1
         mov	eax, DWORD PTR [rsp+176]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+160]
-        roll	edx, 7
+        rol	edx, 7
         vpalignr	xmm4, xmm1, xmm0, 8
         ; iter_40: 2 - 2
         xor	ecx, edx
@@ -2076,24 +2076,24 @@ sm3_compress_avx1 PROC
         add	r15d, ecx
         add	r11d, edx
         mov	ebx, r11d
-        roll	r11d, 8
-        roll	r9d, 9
+        rol	r11d, 8
+        rol	r9d, 9
         xor	r11d, ebx
-        roll	r13d, 19
-        roll	r11d, 9
+        rol	r13d, 19
+        rol	r11d, 9
         xor	r11d, ebx
         vpxor	xmm10, xmm2, xmm10
         ; iter_41: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+328]
         mov	ecx, r15d
         add	edx, r11d
-        roll	ecx, 12
+        rol	ecx, 12
         vpshufd	xmm4, xmm1, 249
         ; iter_41: 1 - 2
         mov	eax, DWORD PTR [rsp+180]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+164]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -2123,27 +2123,27 @@ sm3_compress_avx1 PROC
         add	r14d, ecx
         add	r10d, edx
         mov	ebx, r10d
-        roll	r10d, 8
+        rol	r10d, 8
         vpslld	xmm6, xmm4, 23
         vpsrld	xmm5, xmm4, 9
         ; iter_41: 7 - 7
-        roll	r8d, 9
+        rol	r8d, 9
         xor	r10d, ebx
-        roll	r12d, 19
-        roll	r10d, 9
+        rol	r12d, 19
+        rol	r10d, 9
         xor	r10d, ebx
         ; iter_42: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+336]
         mov	ecx, r14d
         add	edx, r10d
-        roll	ecx, 12
+        rol	ecx, 12
         vpor	xmm8, xmm7, xmm8
         vpor	xmm6, xmm5, xmm6
         ; iter_42: 1 - 1
         mov	eax, DWORD PTR [rsp+184]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+168]
-        roll	edx, 7
+        rol	edx, 7
         vpxor	xmm8, xmm6, xmm8
         vpxor	xmm4, xmm9, xmm4
         ; iter_42: 2 - 2
@@ -2173,27 +2173,27 @@ sm3_compress_avx1 PROC
         add	r13d, ecx
         add	r9d, edx
         mov	ebx, r9d
-        roll	r9d, 8
+        rol	r9d, 8
         vpor	xmm4, xmm5, xmm4
         ; iter_42: 7 - 7
-        roll	r15d, 9
+        rol	r15d, 9
         xor	r9d, ebx
-        roll	r11d, 19
-        roll	r9d, 9
+        rol	r11d, 19
+        rol	r9d, 9
         xor	r9d, ebx
         vpxor	xmm10, xmm4, xmm10
         ; iter_43: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+344]
         mov	ecx, r13d
         add	edx, r9d
-        roll	ecx, 12
+        rol	ecx, 12
         vpslld	xmm7, xmm10, 15
         vpsrld	xmm6, xmm10, 17
         ; iter_43: 1 - 1
         mov	eax, DWORD PTR [rsp+188]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+172]
-        roll	edx, 7
+        rol	edx, 7
         vpslld	xmm5, xmm10, 23
         vpsrld	xmm4, xmm10, 9
         ; iter_43: 2 - 2
@@ -2226,12 +2226,12 @@ sm3_compress_avx1 PROC
         add	r12d, ecx
         add	r8d, edx
         mov	ebx, r8d
-        roll	r8d, 8
+        rol	r8d, 8
         ; iter_43: 7 - 7
-        roll	r14d, 9
+        rol	r14d, 9
         xor	r8d, ebx
-        roll	r10d, 19
-        roll	r8d, 9
+        rol	r10d, 19
+        rol	r8d, 9
         xor	r8d, ebx
         ; msg_sched done: 40-43
         ; msg_sched: 44-47
@@ -2239,13 +2239,13 @@ sm3_compress_avx1 PROC
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+352]
         mov	ecx, r12d
         add	edx, r8d
-        roll	ecx, 12
+        rol	ecx, 12
         vpalignr	xmm5, xmm0, xmm3, 12
         ; iter_44: 1 - 1
         mov	eax, DWORD PTR [rsp+192]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+176]
-        roll	edx, 7
+        rol	edx, 7
         vpalignr	xmm4, xmm2, xmm1, 8
         ; iter_44: 2 - 2
         xor	ecx, edx
@@ -2276,24 +2276,24 @@ sm3_compress_avx1 PROC
         add	r11d, ecx
         add	r15d, edx
         mov	ebx, r15d
-        roll	r15d, 8
-        roll	r13d, 9
+        rol	r15d, 8
+        rol	r13d, 9
         xor	r15d, ebx
-        roll	r9d, 19
-        roll	r15d, 9
+        rol	r9d, 19
+        rol	r15d, 9
         xor	r15d, ebx
         vpxor	xmm10, xmm3, xmm10
         ; iter_45: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+360]
         mov	ecx, r11d
         add	edx, r15d
-        roll	ecx, 12
+        rol	ecx, 12
         vpshufd	xmm4, xmm2, 249
         ; iter_45: 1 - 2
         mov	eax, DWORD PTR [rsp+196]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+180]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -2323,27 +2323,27 @@ sm3_compress_avx1 PROC
         add	r10d, ecx
         add	r14d, edx
         mov	ebx, r14d
-        roll	r14d, 8
+        rol	r14d, 8
         vpslld	xmm6, xmm4, 23
         vpsrld	xmm5, xmm4, 9
         ; iter_45: 7 - 7
-        roll	r12d, 9
+        rol	r12d, 9
         xor	r14d, ebx
-        roll	r8d, 19
-        roll	r14d, 9
+        rol	r8d, 19
+        rol	r14d, 9
         xor	r14d, ebx
         ; iter_46: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+368]
         mov	ecx, r10d
         add	edx, r14d
-        roll	ecx, 12
+        rol	ecx, 12
         vpor	xmm8, xmm7, xmm8
         vpor	xmm6, xmm5, xmm6
         ; iter_46: 1 - 1
         mov	eax, DWORD PTR [rsp+200]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+184]
-        roll	edx, 7
+        rol	edx, 7
         vpxor	xmm8, xmm6, xmm8
         vpxor	xmm4, xmm9, xmm4
         ; iter_46: 2 - 2
@@ -2373,27 +2373,27 @@ sm3_compress_avx1 PROC
         add	r9d, ecx
         add	r13d, edx
         mov	ebx, r13d
-        roll	r13d, 8
+        rol	r13d, 8
         vpor	xmm4, xmm5, xmm4
         ; iter_46: 7 - 7
-        roll	r11d, 9
+        rol	r11d, 9
         xor	r13d, ebx
-        roll	r15d, 19
-        roll	r13d, 9
+        rol	r15d, 19
+        rol	r13d, 9
         xor	r13d, ebx
         vpxor	xmm10, xmm4, xmm10
         ; iter_47: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+376]
         mov	ecx, r9d
         add	edx, r13d
-        roll	ecx, 12
+        rol	ecx, 12
         vpslld	xmm7, xmm10, 15
         vpsrld	xmm6, xmm10, 17
         ; iter_47: 1 - 1
         mov	eax, DWORD PTR [rsp+204]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+188]
-        roll	edx, 7
+        rol	edx, 7
         vpslld	xmm5, xmm10, 23
         vpsrld	xmm4, xmm10, 9
         ; iter_47: 2 - 2
@@ -2426,12 +2426,12 @@ sm3_compress_avx1 PROC
         add	r8d, ecx
         add	r12d, edx
         mov	ebx, r12d
-        roll	r12d, 8
+        rol	r12d, 8
         ; iter_47: 7 - 7
-        roll	r10d, 9
+        rol	r10d, 9
         xor	r12d, ebx
-        roll	r14d, 19
-        roll	r12d, 9
+        rol	r14d, 19
+        rol	r12d, 9
         xor	r12d, ebx
         ; msg_sched done: 44-47
         ; x2_to_w: 56
@@ -2442,13 +2442,13 @@ sm3_compress_avx1 PROC
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+384]
         mov	ecx, r8d
         add	edx, r12d
-        roll	ecx, 12
+        rol	ecx, 12
         vpalignr	xmm5, xmm1, xmm0, 12
         ; iter_48: 1 - 1
         mov	eax, DWORD PTR [rsp+208]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+192]
-        roll	edx, 7
+        rol	edx, 7
         vpalignr	xmm4, xmm3, xmm2, 8
         ; iter_48: 2 - 2
         xor	ecx, edx
@@ -2479,24 +2479,24 @@ sm3_compress_avx1 PROC
         add	r15d, ecx
         add	r11d, edx
         mov	ebx, r11d
-        roll	r11d, 8
-        roll	r9d, 9
+        rol	r11d, 8
+        rol	r9d, 9
         xor	r11d, ebx
-        roll	r13d, 19
-        roll	r11d, 9
+        rol	r13d, 19
+        rol	r11d, 9
         xor	r11d, ebx
         vpxor	xmm10, xmm0, xmm10
         ; iter_49: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+392]
         mov	ecx, r15d
         add	edx, r11d
-        roll	ecx, 12
+        rol	ecx, 12
         vpshufd	xmm4, xmm3, 249
         ; iter_49: 1 - 2
         mov	eax, DWORD PTR [rsp+212]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+196]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -2526,27 +2526,27 @@ sm3_compress_avx1 PROC
         add	r14d, ecx
         add	r10d, edx
         mov	ebx, r10d
-        roll	r10d, 8
+        rol	r10d, 8
         vpslld	xmm6, xmm4, 23
         vpsrld	xmm5, xmm4, 9
         ; iter_49: 7 - 7
-        roll	r8d, 9
+        rol	r8d, 9
         xor	r10d, ebx
-        roll	r12d, 19
-        roll	r10d, 9
+        rol	r12d, 19
+        rol	r10d, 9
         xor	r10d, ebx
         ; iter_50: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+400]
         mov	ecx, r14d
         add	edx, r10d
-        roll	ecx, 12
+        rol	ecx, 12
         vpor	xmm8, xmm7, xmm8
         vpor	xmm6, xmm5, xmm6
         ; iter_50: 1 - 1
         mov	eax, DWORD PTR [rsp+216]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+200]
-        roll	edx, 7
+        rol	edx, 7
         vpxor	xmm8, xmm6, xmm8
         vpxor	xmm4, xmm9, xmm4
         ; iter_50: 2 - 2
@@ -2576,27 +2576,27 @@ sm3_compress_avx1 PROC
         add	r13d, ecx
         add	r9d, edx
         mov	ebx, r9d
-        roll	r9d, 8
+        rol	r9d, 8
         vpor	xmm4, xmm5, xmm4
         ; iter_50: 7 - 7
-        roll	r15d, 9
+        rol	r15d, 9
         xor	r9d, ebx
-        roll	r11d, 19
-        roll	r9d, 9
+        rol	r11d, 19
+        rol	r9d, 9
         xor	r9d, ebx
         vpxor	xmm10, xmm4, xmm10
         ; iter_51: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+408]
         mov	ecx, r13d
         add	edx, r9d
-        roll	ecx, 12
+        rol	ecx, 12
         vpslld	xmm7, xmm10, 15
         vpsrld	xmm6, xmm10, 17
         ; iter_51: 1 - 1
         mov	eax, DWORD PTR [rsp+220]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+204]
-        roll	edx, 7
+        rol	edx, 7
         vpslld	xmm5, xmm10, 23
         vpsrld	xmm4, xmm10, 9
         ; iter_51: 2 - 2
@@ -2629,23 +2629,23 @@ sm3_compress_avx1 PROC
         add	r12d, ecx
         add	r8d, edx
         mov	ebx, r8d
-        roll	r8d, 8
+        rol	r8d, 8
         ; iter_51: 7 - 7
-        roll	r14d, 9
+        rol	r14d, 9
         xor	r8d, ebx
-        roll	r10d, 19
-        roll	r8d, 9
+        rol	r10d, 19
+        rol	r8d, 9
         xor	r8d, ebx
         ; msg_sched done: 48-51
         ; iter_52: 0 - 7
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+416]
         mov	ecx, r12d
         add	edx, r8d
-        roll	ecx, 12
+        rol	ecx, 12
         mov	eax, DWORD PTR [rsp+224]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+208]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -2665,21 +2665,21 @@ sm3_compress_avx1 PROC
         add	r11d, ecx
         add	r15d, edx
         mov	ebx, r15d
-        roll	r15d, 8
-        roll	r13d, 9
+        rol	r15d, 8
+        rol	r13d, 9
         xor	r15d, ebx
-        roll	r9d, 19
-        roll	r15d, 9
+        rol	r9d, 19
+        rol	r15d, 9
         xor	r15d, ebx
         ; iter_53: 0 - 7
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+424]
         mov	ecx, r11d
         add	edx, r15d
-        roll	ecx, 12
+        rol	ecx, 12
         mov	eax, DWORD PTR [rsp+228]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+212]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -2699,21 +2699,21 @@ sm3_compress_avx1 PROC
         add	r10d, ecx
         add	r14d, edx
         mov	ebx, r14d
-        roll	r14d, 8
-        roll	r12d, 9
+        rol	r14d, 8
+        rol	r12d, 9
         xor	r14d, ebx
-        roll	r8d, 19
-        roll	r14d, 9
+        rol	r8d, 19
+        rol	r14d, 9
         xor	r14d, ebx
         ; iter_54: 0 - 7
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+432]
         mov	ecx, r10d
         add	edx, r14d
-        roll	ecx, 12
+        rol	ecx, 12
         mov	eax, DWORD PTR [rsp+232]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+216]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -2733,21 +2733,21 @@ sm3_compress_avx1 PROC
         add	r9d, ecx
         add	r13d, edx
         mov	ebx, r13d
-        roll	r13d, 8
-        roll	r11d, 9
+        rol	r13d, 8
+        rol	r11d, 9
         xor	r13d, ebx
-        roll	r15d, 19
-        roll	r13d, 9
+        rol	r15d, 19
+        rol	r13d, 9
         xor	r13d, ebx
         ; iter_55: 0 - 7
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+440]
         mov	ecx, r9d
         add	edx, r13d
-        roll	ecx, 12
+        rol	ecx, 12
         mov	eax, DWORD PTR [rsp+236]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+220]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -2767,11 +2767,11 @@ sm3_compress_avx1 PROC
         add	r8d, ecx
         add	r12d, edx
         mov	ebx, r12d
-        roll	r12d, 8
-        roll	r10d, 9
+        rol	r12d, 8
+        rol	r10d, 9
         xor	r12d, ebx
-        roll	r14d, 19
-        roll	r12d, 9
+        rol	r14d, 19
+        rol	r12d, 9
         xor	r12d, ebx
         ; x0_to_w: 64
         vmovdqu	OWORD PTR [rsp+256], xmm0
@@ -2779,11 +2779,11 @@ sm3_compress_avx1 PROC
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+448]
         mov	ecx, r8d
         add	edx, r12d
-        roll	ecx, 12
+        rol	ecx, 12
         mov	eax, DWORD PTR [rsp+240]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+224]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -2803,21 +2803,21 @@ sm3_compress_avx1 PROC
         add	r15d, ecx
         add	r11d, edx
         mov	ebx, r11d
-        roll	r11d, 8
-        roll	r9d, 9
+        rol	r11d, 8
+        rol	r9d, 9
         xor	r11d, ebx
-        roll	r13d, 19
-        roll	r11d, 9
+        rol	r13d, 19
+        rol	r11d, 9
         xor	r11d, ebx
         ; iter_57: 0 - 7
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+456]
         mov	ecx, r15d
         add	edx, r11d
-        roll	ecx, 12
+        rol	ecx, 12
         mov	eax, DWORD PTR [rsp+244]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+228]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -2837,21 +2837,21 @@ sm3_compress_avx1 PROC
         add	r14d, ecx
         add	r10d, edx
         mov	ebx, r10d
-        roll	r10d, 8
-        roll	r8d, 9
+        rol	r10d, 8
+        rol	r8d, 9
         xor	r10d, ebx
-        roll	r12d, 19
-        roll	r10d, 9
+        rol	r12d, 19
+        rol	r10d, 9
         xor	r10d, ebx
         ; iter_58: 0 - 7
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+464]
         mov	ecx, r14d
         add	edx, r10d
-        roll	ecx, 12
+        rol	ecx, 12
         mov	eax, DWORD PTR [rsp+248]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+232]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -2871,21 +2871,21 @@ sm3_compress_avx1 PROC
         add	r13d, ecx
         add	r9d, edx
         mov	ebx, r9d
-        roll	r9d, 8
-        roll	r15d, 9
+        rol	r9d, 8
+        rol	r15d, 9
         xor	r9d, ebx
-        roll	r11d, 19
-        roll	r9d, 9
+        rol	r11d, 19
+        rol	r9d, 9
         xor	r9d, ebx
         ; iter_59: 0 - 7
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+472]
         mov	ecx, r13d
         add	edx, r9d
-        roll	ecx, 12
+        rol	ecx, 12
         mov	eax, DWORD PTR [rsp+252]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+236]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -2905,21 +2905,21 @@ sm3_compress_avx1 PROC
         add	r12d, ecx
         add	r8d, edx
         mov	ebx, r8d
-        roll	r8d, 8
-        roll	r14d, 9
+        rol	r8d, 8
+        rol	r14d, 9
         xor	r8d, ebx
-        roll	r10d, 19
-        roll	r8d, 9
+        rol	r10d, 19
+        rol	r8d, 9
         xor	r8d, ebx
         ; iter_60: 0 - 7
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+480]
         mov	ecx, r12d
         add	edx, r8d
-        roll	ecx, 12
+        rol	ecx, 12
         mov	eax, DWORD PTR [rsp+256]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+240]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -2939,21 +2939,21 @@ sm3_compress_avx1 PROC
         add	r11d, ecx
         add	r15d, edx
         mov	ebx, r15d
-        roll	r15d, 8
-        roll	r13d, 9
+        rol	r15d, 8
+        rol	r13d, 9
         xor	r15d, ebx
-        roll	r9d, 19
-        roll	r15d, 9
+        rol	r9d, 19
+        rol	r15d, 9
         xor	r15d, ebx
         ; iter_61: 0 - 7
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+488]
         mov	ecx, r11d
         add	edx, r15d
-        roll	ecx, 12
+        rol	ecx, 12
         mov	eax, DWORD PTR [rsp+260]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+244]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -2973,21 +2973,21 @@ sm3_compress_avx1 PROC
         add	r10d, ecx
         add	r14d, edx
         mov	ebx, r14d
-        roll	r14d, 8
-        roll	r12d, 9
+        rol	r14d, 8
+        rol	r12d, 9
         xor	r14d, ebx
-        roll	r8d, 19
-        roll	r14d, 9
+        rol	r8d, 19
+        rol	r14d, 9
         xor	r14d, ebx
         ; iter_62: 0 - 7
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+496]
         mov	ecx, r10d
         add	edx, r14d
-        roll	ecx, 12
+        rol	ecx, 12
         mov	eax, DWORD PTR [rsp+264]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+248]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -3007,21 +3007,21 @@ sm3_compress_avx1 PROC
         add	r9d, ecx
         add	r13d, edx
         mov	ebx, r13d
-        roll	r13d, 8
-        roll	r11d, 9
+        rol	r13d, 8
+        rol	r11d, 9
         xor	r13d, ebx
-        roll	r15d, 19
-        roll	r13d, 9
+        rol	r15d, 19
+        rol	r13d, 9
         xor	r13d, ebx
         ; iter_63: 0 - 7
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+504]
         mov	ecx, r9d
         add	edx, r13d
-        roll	ecx, 12
+        rol	ecx, 12
         mov	eax, DWORD PTR [rsp+268]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+252]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -3041,11 +3041,11 @@ sm3_compress_avx1 PROC
         add	r8d, ecx
         add	r12d, edx
         mov	ebx, r12d
-        roll	r12d, 8
-        roll	r10d, 9
+        rol	r12d, 8
+        rol	r10d, 9
         xor	r12d, ebx
-        roll	r14d, 19
-        roll	r12d, 9
+        rol	r14d, 19
+        rol	r12d, 9
         xor	r12d, ebx
         xor	DWORD PTR [rdi], r8d
         xor	DWORD PTR [rdi+4], r9d
@@ -3111,13 +3111,13 @@ L_SM3_AVX1len_start:
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t]
         mov	ecx, r8d
         add	edx, r12d
-        roll	ecx, 12
+        rol	ecx, 12
         vpalignr	xmm5, xmm1, xmm0, 12
         ; iter_0: 1 - 1
         mov	eax, DWORD PTR [rsp+16]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp]
-        roll	edx, 7
+        rol	edx, 7
         vpalignr	xmm4, xmm3, xmm2, 8
         ; iter_0: 2 - 2
         xor	ecx, edx
@@ -3142,26 +3142,26 @@ L_SM3_AVX1len_start:
         add	r15d, ecx
         add	r11d, edx
         mov	ebx, r11d
-        roll	r11d, 8
+        rol	r11d, 8
         vpalignr	xmm10, xmm2, xmm1, 12
         ; iter_0: 6 - 7
-        roll	r9d, 9
+        rol	r9d, 9
         xor	r11d, ebx
-        roll	r13d, 19
-        roll	r11d, 9
+        rol	r13d, 19
+        rol	r11d, 9
         xor	r11d, ebx
         vpxor	xmm10, xmm0, xmm10
         ; iter_1: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+8]
         mov	ecx, r15d
         add	edx, r11d
-        roll	ecx, 12
+        rol	ecx, 12
         vpshufd	xmm4, xmm3, 249
         ; iter_1: 1 - 2
         mov	eax, DWORD PTR [rsp+20]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+4]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -3184,14 +3184,14 @@ L_SM3_AVX1len_start:
         add	r14d, ecx
         add	r10d, edx
         mov	ebx, r10d
-        roll	r10d, 8
+        rol	r10d, 8
         vpslld	xmm8, xmm4, 15
         vpsrld	xmm7, xmm4, 17
         ; iter_1: 6 - 6
-        roll	r8d, 9
+        rol	r8d, 9
         xor	r10d, ebx
-        roll	r12d, 19
-        roll	r10d, 9
+        rol	r12d, 19
+        rol	r10d, 9
         vpslld	xmm6, xmm4, 23
         vpsrld	xmm5, xmm4, 9
         ; iter_1: 7 - 7
@@ -3200,14 +3200,14 @@ L_SM3_AVX1len_start:
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+16]
         mov	ecx, r14d
         add	edx, r10d
-        roll	ecx, 12
+        rol	ecx, 12
         vpor	xmm8, xmm7, xmm8
         vpor	xmm6, xmm5, xmm6
         ; iter_2: 1 - 1
         mov	eax, DWORD PTR [rsp+24]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+8]
-        roll	edx, 7
+        rol	edx, 7
         vpxor	xmm8, xmm6, xmm8
         vpxor	xmm4, xmm9, xmm4
         ; iter_2: 2 - 2
@@ -3230,14 +3230,14 @@ L_SM3_AVX1len_start:
         add	r13d, ecx
         add	r9d, edx
         mov	ebx, r9d
-        roll	r9d, 8
+        rol	r9d, 8
         vpslld	xmm5, xmm4, 15
         vpsrld	xmm4, xmm4, 17
         ; iter_2: 6 - 6
-        roll	r15d, 9
+        rol	r15d, 9
         xor	r9d, ebx
-        roll	r11d, 19
-        roll	r9d, 9
+        rol	r11d, 19
+        rol	r9d, 9
         vpor	xmm4, xmm5, xmm4
         ; iter_2: 7 - 7
         xor	r9d, ebx
@@ -3246,14 +3246,14 @@ L_SM3_AVX1len_start:
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+24]
         mov	ecx, r13d
         add	edx, r9d
-        roll	ecx, 12
+        rol	ecx, 12
         vpslld	xmm7, xmm10, 15
         vpsrld	xmm6, xmm10, 17
         ; iter_3: 1 - 1
         mov	eax, DWORD PTR [rsp+28]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+12]
-        roll	edx, 7
+        rol	edx, 7
         vpslld	xmm5, xmm10, 23
         vpsrld	xmm4, xmm10, 9
         ; iter_3: 2 - 2
@@ -3280,13 +3280,13 @@ L_SM3_AVX1len_start:
         add	r12d, ecx
         add	r8d, edx
         mov	ebx, r8d
-        roll	r8d, 8
+        rol	r8d, 8
         vpblendw	xmm0, xmm8, xmm10, 192
         ; iter_3: 6 - 6
-        roll	r14d, 9
+        rol	r14d, 9
         xor	r8d, ebx
-        roll	r10d, 19
-        roll	r8d, 9
+        rol	r10d, 19
+        rol	r8d, 9
         ; iter_3: 7 - 7
         xor	r8d, ebx
         ; msg_sched done: 0-3
@@ -3295,13 +3295,13 @@ L_SM3_AVX1len_start:
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+32]
         mov	ecx, r12d
         add	edx, r8d
-        roll	ecx, 12
+        rol	ecx, 12
         vpalignr	xmm5, xmm2, xmm1, 12
         ; iter_4: 1 - 1
         mov	eax, DWORD PTR [rsp+32]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+16]
-        roll	edx, 7
+        rol	edx, 7
         vpalignr	xmm4, xmm0, xmm3, 8
         ; iter_4: 2 - 2
         xor	ecx, edx
@@ -3326,26 +3326,26 @@ L_SM3_AVX1len_start:
         add	r11d, ecx
         add	r15d, edx
         mov	ebx, r15d
-        roll	r15d, 8
+        rol	r15d, 8
         vpalignr	xmm10, xmm3, xmm2, 12
         ; iter_4: 6 - 7
-        roll	r13d, 9
+        rol	r13d, 9
         xor	r15d, ebx
-        roll	r9d, 19
-        roll	r15d, 9
+        rol	r9d, 19
+        rol	r15d, 9
         xor	r15d, ebx
         vpxor	xmm10, xmm1, xmm10
         ; iter_5: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+40]
         mov	ecx, r11d
         add	edx, r15d
-        roll	ecx, 12
+        rol	ecx, 12
         vpshufd	xmm4, xmm0, 249
         ; iter_5: 1 - 2
         mov	eax, DWORD PTR [rsp+36]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+20]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -3368,14 +3368,14 @@ L_SM3_AVX1len_start:
         add	r10d, ecx
         add	r14d, edx
         mov	ebx, r14d
-        roll	r14d, 8
+        rol	r14d, 8
         vpslld	xmm8, xmm4, 15
         vpsrld	xmm7, xmm4, 17
         ; iter_5: 6 - 6
-        roll	r12d, 9
+        rol	r12d, 9
         xor	r14d, ebx
-        roll	r8d, 19
-        roll	r14d, 9
+        rol	r8d, 19
+        rol	r14d, 9
         vpslld	xmm6, xmm4, 23
         vpsrld	xmm5, xmm4, 9
         ; iter_5: 7 - 7
@@ -3384,14 +3384,14 @@ L_SM3_AVX1len_start:
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+48]
         mov	ecx, r10d
         add	edx, r14d
-        roll	ecx, 12
+        rol	ecx, 12
         vpor	xmm8, xmm7, xmm8
         vpor	xmm6, xmm5, xmm6
         ; iter_6: 1 - 1
         mov	eax, DWORD PTR [rsp+40]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+24]
-        roll	edx, 7
+        rol	edx, 7
         vpxor	xmm8, xmm6, xmm8
         vpxor	xmm4, xmm9, xmm4
         ; iter_6: 2 - 2
@@ -3414,14 +3414,14 @@ L_SM3_AVX1len_start:
         add	r9d, ecx
         add	r13d, edx
         mov	ebx, r13d
-        roll	r13d, 8
+        rol	r13d, 8
         vpslld	xmm5, xmm4, 15
         vpsrld	xmm4, xmm4, 17
         ; iter_6: 6 - 6
-        roll	r11d, 9
+        rol	r11d, 9
         xor	r13d, ebx
-        roll	r15d, 19
-        roll	r13d, 9
+        rol	r15d, 19
+        rol	r13d, 9
         vpor	xmm4, xmm5, xmm4
         ; iter_6: 7 - 7
         xor	r13d, ebx
@@ -3430,14 +3430,14 @@ L_SM3_AVX1len_start:
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+56]
         mov	ecx, r9d
         add	edx, r13d
-        roll	ecx, 12
+        rol	ecx, 12
         vpslld	xmm7, xmm10, 15
         vpsrld	xmm6, xmm10, 17
         ; iter_7: 1 - 1
         mov	eax, DWORD PTR [rsp+44]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+28]
-        roll	edx, 7
+        rol	edx, 7
         vpslld	xmm5, xmm10, 23
         vpsrld	xmm4, xmm10, 9
         ; iter_7: 2 - 2
@@ -3464,13 +3464,13 @@ L_SM3_AVX1len_start:
         add	r8d, ecx
         add	r12d, edx
         mov	ebx, r12d
-        roll	r12d, 8
+        rol	r12d, 8
         vpblendw	xmm1, xmm8, xmm10, 192
         ; iter_7: 6 - 6
-        roll	r10d, 9
+        rol	r10d, 9
         xor	r12d, ebx
-        roll	r14d, 19
-        roll	r12d, 9
+        rol	r14d, 19
+        rol	r12d, 9
         ; iter_7: 7 - 7
         xor	r12d, ebx
         ; msg_sched done: 4-7
@@ -3482,13 +3482,13 @@ L_SM3_AVX1len_start:
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+64]
         mov	ecx, r8d
         add	edx, r12d
-        roll	ecx, 12
+        rol	ecx, 12
         vpalignr	xmm5, xmm3, xmm2, 12
         ; iter_8: 1 - 1
         mov	eax, DWORD PTR [rsp+48]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+32]
-        roll	edx, 7
+        rol	edx, 7
         vpalignr	xmm4, xmm1, xmm0, 8
         ; iter_8: 2 - 2
         xor	ecx, edx
@@ -3513,26 +3513,26 @@ L_SM3_AVX1len_start:
         add	r15d, ecx
         add	r11d, edx
         mov	ebx, r11d
-        roll	r11d, 8
+        rol	r11d, 8
         vpalignr	xmm10, xmm0, xmm3, 12
         ; iter_8: 6 - 7
-        roll	r9d, 9
+        rol	r9d, 9
         xor	r11d, ebx
-        roll	r13d, 19
-        roll	r11d, 9
+        rol	r13d, 19
+        rol	r11d, 9
         xor	r11d, ebx
         vpxor	xmm10, xmm2, xmm10
         ; iter_9: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+72]
         mov	ecx, r15d
         add	edx, r11d
-        roll	ecx, 12
+        rol	ecx, 12
         vpshufd	xmm4, xmm1, 249
         ; iter_9: 1 - 2
         mov	eax, DWORD PTR [rsp+52]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+36]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -3555,14 +3555,14 @@ L_SM3_AVX1len_start:
         add	r14d, ecx
         add	r10d, edx
         mov	ebx, r10d
-        roll	r10d, 8
+        rol	r10d, 8
         vpslld	xmm8, xmm4, 15
         vpsrld	xmm7, xmm4, 17
         ; iter_9: 6 - 6
-        roll	r8d, 9
+        rol	r8d, 9
         xor	r10d, ebx
-        roll	r12d, 19
-        roll	r10d, 9
+        rol	r12d, 19
+        rol	r10d, 9
         vpslld	xmm6, xmm4, 23
         vpsrld	xmm5, xmm4, 9
         ; iter_9: 7 - 7
@@ -3571,14 +3571,14 @@ L_SM3_AVX1len_start:
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+80]
         mov	ecx, r14d
         add	edx, r10d
-        roll	ecx, 12
+        rol	ecx, 12
         vpor	xmm8, xmm7, xmm8
         vpor	xmm6, xmm5, xmm6
         ; iter_10: 1 - 1
         mov	eax, DWORD PTR [rsp+56]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+40]
-        roll	edx, 7
+        rol	edx, 7
         vpxor	xmm8, xmm6, xmm8
         vpxor	xmm4, xmm9, xmm4
         ; iter_10: 2 - 2
@@ -3601,14 +3601,14 @@ L_SM3_AVX1len_start:
         add	r13d, ecx
         add	r9d, edx
         mov	ebx, r9d
-        roll	r9d, 8
+        rol	r9d, 8
         vpslld	xmm5, xmm4, 15
         vpsrld	xmm4, xmm4, 17
         ; iter_10: 6 - 6
-        roll	r15d, 9
+        rol	r15d, 9
         xor	r9d, ebx
-        roll	r11d, 19
-        roll	r9d, 9
+        rol	r11d, 19
+        rol	r9d, 9
         vpor	xmm4, xmm5, xmm4
         ; iter_10: 7 - 7
         xor	r9d, ebx
@@ -3617,14 +3617,14 @@ L_SM3_AVX1len_start:
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+88]
         mov	ecx, r13d
         add	edx, r9d
-        roll	ecx, 12
+        rol	ecx, 12
         vpslld	xmm7, xmm10, 15
         vpsrld	xmm6, xmm10, 17
         ; iter_11: 1 - 1
         mov	eax, DWORD PTR [rsp+60]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+44]
-        roll	edx, 7
+        rol	edx, 7
         vpslld	xmm5, xmm10, 23
         vpsrld	xmm4, xmm10, 9
         ; iter_11: 2 - 2
@@ -3651,13 +3651,13 @@ L_SM3_AVX1len_start:
         add	r12d, ecx
         add	r8d, edx
         mov	ebx, r8d
-        roll	r8d, 8
+        rol	r8d, 8
         vpblendw	xmm2, xmm8, xmm10, 192
         ; iter_11: 6 - 6
-        roll	r14d, 9
+        rol	r14d, 9
         xor	r8d, ebx
-        roll	r10d, 19
-        roll	r8d, 9
+        rol	r10d, 19
+        rol	r8d, 9
         ; iter_11: 7 - 7
         xor	r8d, ebx
         ; msg_sched done: 8-11
@@ -3666,13 +3666,13 @@ L_SM3_AVX1len_start:
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+96]
         mov	ecx, r12d
         add	edx, r8d
-        roll	ecx, 12
+        rol	ecx, 12
         vpalignr	xmm5, xmm0, xmm3, 12
         ; iter_12: 1 - 1
         mov	eax, DWORD PTR [rsp+64]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+48]
-        roll	edx, 7
+        rol	edx, 7
         vpalignr	xmm4, xmm2, xmm1, 8
         ; iter_12: 2 - 2
         xor	ecx, edx
@@ -3697,26 +3697,26 @@ L_SM3_AVX1len_start:
         add	r11d, ecx
         add	r15d, edx
         mov	ebx, r15d
-        roll	r15d, 8
+        rol	r15d, 8
         vpalignr	xmm10, xmm1, xmm0, 12
         ; iter_12: 6 - 7
-        roll	r13d, 9
+        rol	r13d, 9
         xor	r15d, ebx
-        roll	r9d, 19
-        roll	r15d, 9
+        rol	r9d, 19
+        rol	r15d, 9
         xor	r15d, ebx
         vpxor	xmm10, xmm3, xmm10
         ; iter_13: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+104]
         mov	ecx, r11d
         add	edx, r15d
-        roll	ecx, 12
+        rol	ecx, 12
         vpshufd	xmm4, xmm2, 249
         ; iter_13: 1 - 2
         mov	eax, DWORD PTR [rsp+68]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+52]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -3739,14 +3739,14 @@ L_SM3_AVX1len_start:
         add	r10d, ecx
         add	r14d, edx
         mov	ebx, r14d
-        roll	r14d, 8
+        rol	r14d, 8
         vpslld	xmm8, xmm4, 15
         vpsrld	xmm7, xmm4, 17
         ; iter_13: 6 - 6
-        roll	r12d, 9
+        rol	r12d, 9
         xor	r14d, ebx
-        roll	r8d, 19
-        roll	r14d, 9
+        rol	r8d, 19
+        rol	r14d, 9
         vpslld	xmm6, xmm4, 23
         vpsrld	xmm5, xmm4, 9
         ; iter_13: 7 - 7
@@ -3755,14 +3755,14 @@ L_SM3_AVX1len_start:
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+112]
         mov	ecx, r10d
         add	edx, r14d
-        roll	ecx, 12
+        rol	ecx, 12
         vpor	xmm8, xmm7, xmm8
         vpor	xmm6, xmm5, xmm6
         ; iter_14: 1 - 1
         mov	eax, DWORD PTR [rsp+72]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+56]
-        roll	edx, 7
+        rol	edx, 7
         vpxor	xmm8, xmm6, xmm8
         vpxor	xmm4, xmm9, xmm4
         ; iter_14: 2 - 2
@@ -3785,14 +3785,14 @@ L_SM3_AVX1len_start:
         add	r9d, ecx
         add	r13d, edx
         mov	ebx, r13d
-        roll	r13d, 8
+        rol	r13d, 8
         vpslld	xmm5, xmm4, 15
         vpsrld	xmm4, xmm4, 17
         ; iter_14: 6 - 6
-        roll	r11d, 9
+        rol	r11d, 9
         xor	r13d, ebx
-        roll	r15d, 19
-        roll	r13d, 9
+        rol	r15d, 19
+        rol	r13d, 9
         vpor	xmm4, xmm5, xmm4
         ; iter_14: 7 - 7
         xor	r13d, ebx
@@ -3801,14 +3801,14 @@ L_SM3_AVX1len_start:
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+120]
         mov	ecx, r9d
         add	edx, r13d
-        roll	ecx, 12
+        rol	ecx, 12
         vpslld	xmm7, xmm10, 15
         vpsrld	xmm6, xmm10, 17
         ; iter_15: 1 - 1
         mov	eax, DWORD PTR [rsp+76]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+60]
-        roll	edx, 7
+        rol	edx, 7
         vpslld	xmm5, xmm10, 23
         vpsrld	xmm4, xmm10, 9
         ; iter_15: 2 - 2
@@ -3835,13 +3835,13 @@ L_SM3_AVX1len_start:
         add	r8d, ecx
         add	r12d, edx
         mov	ebx, r12d
-        roll	r12d, 8
+        rol	r12d, 8
         vpblendw	xmm3, xmm8, xmm10, 192
         ; iter_15: 6 - 6
-        roll	r10d, 9
+        rol	r10d, 9
         xor	r12d, ebx
-        roll	r14d, 19
-        roll	r12d, 9
+        rol	r14d, 19
+        rol	r12d, 9
         ; iter_15: 7 - 7
         xor	r12d, ebx
         ; msg_sched done: 12-15
@@ -3853,13 +3853,13 @@ L_SM3_AVX1len_start:
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+128]
         mov	ecx, r8d
         add	edx, r12d
-        roll	ecx, 12
+        rol	ecx, 12
         vpalignr	xmm5, xmm1, xmm0, 12
         ; iter_16: 1 - 1
         mov	eax, DWORD PTR [rsp+80]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+64]
-        roll	edx, 7
+        rol	edx, 7
         vpalignr	xmm4, xmm3, xmm2, 8
         ; iter_16: 2 - 2
         xor	ecx, edx
@@ -3890,24 +3890,24 @@ L_SM3_AVX1len_start:
         add	r15d, ecx
         add	r11d, edx
         mov	ebx, r11d
-        roll	r11d, 8
-        roll	r9d, 9
+        rol	r11d, 8
+        rol	r9d, 9
         xor	r11d, ebx
-        roll	r13d, 19
-        roll	r11d, 9
+        rol	r13d, 19
+        rol	r11d, 9
         xor	r11d, ebx
         vpxor	xmm10, xmm0, xmm10
         ; iter_17: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+136]
         mov	ecx, r15d
         add	edx, r11d
-        roll	ecx, 12
+        rol	ecx, 12
         vpshufd	xmm4, xmm3, 249
         ; iter_17: 1 - 2
         mov	eax, DWORD PTR [rsp+84]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+68]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -3937,27 +3937,27 @@ L_SM3_AVX1len_start:
         add	r14d, ecx
         add	r10d, edx
         mov	ebx, r10d
-        roll	r10d, 8
+        rol	r10d, 8
         vpslld	xmm6, xmm4, 23
         vpsrld	xmm5, xmm4, 9
         ; iter_17: 7 - 7
-        roll	r8d, 9
+        rol	r8d, 9
         xor	r10d, ebx
-        roll	r12d, 19
-        roll	r10d, 9
+        rol	r12d, 19
+        rol	r10d, 9
         xor	r10d, ebx
         ; iter_18: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+144]
         mov	ecx, r14d
         add	edx, r10d
-        roll	ecx, 12
+        rol	ecx, 12
         vpor	xmm8, xmm7, xmm8
         vpor	xmm6, xmm5, xmm6
         ; iter_18: 1 - 1
         mov	eax, DWORD PTR [rsp+88]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+72]
-        roll	edx, 7
+        rol	edx, 7
         vpxor	xmm8, xmm6, xmm8
         vpxor	xmm4, xmm9, xmm4
         ; iter_18: 2 - 2
@@ -3987,27 +3987,27 @@ L_SM3_AVX1len_start:
         add	r13d, ecx
         add	r9d, edx
         mov	ebx, r9d
-        roll	r9d, 8
+        rol	r9d, 8
         vpor	xmm4, xmm5, xmm4
         ; iter_18: 7 - 7
-        roll	r15d, 9
+        rol	r15d, 9
         xor	r9d, ebx
-        roll	r11d, 19
-        roll	r9d, 9
+        rol	r11d, 19
+        rol	r9d, 9
         xor	r9d, ebx
         vpxor	xmm10, xmm4, xmm10
         ; iter_19: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+152]
         mov	ecx, r13d
         add	edx, r9d
-        roll	ecx, 12
+        rol	ecx, 12
         vpslld	xmm7, xmm10, 15
         vpsrld	xmm6, xmm10, 17
         ; iter_19: 1 - 1
         mov	eax, DWORD PTR [rsp+92]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+76]
-        roll	edx, 7
+        rol	edx, 7
         vpslld	xmm5, xmm10, 23
         vpsrld	xmm4, xmm10, 9
         ; iter_19: 2 - 2
@@ -4040,12 +4040,12 @@ L_SM3_AVX1len_start:
         add	r12d, ecx
         add	r8d, edx
         mov	ebx, r8d
-        roll	r8d, 8
+        rol	r8d, 8
         ; iter_19: 7 - 7
-        roll	r14d, 9
+        rol	r14d, 9
         xor	r8d, ebx
-        roll	r10d, 19
-        roll	r8d, 9
+        rol	r10d, 19
+        rol	r8d, 9
         xor	r8d, ebx
         ; msg_sched done: 16-19
         ; msg_sched: 20-23
@@ -4053,13 +4053,13 @@ L_SM3_AVX1len_start:
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+160]
         mov	ecx, r12d
         add	edx, r8d
-        roll	ecx, 12
+        rol	ecx, 12
         vpalignr	xmm5, xmm2, xmm1, 12
         ; iter_20: 1 - 1
         mov	eax, DWORD PTR [rsp+96]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+80]
-        roll	edx, 7
+        rol	edx, 7
         vpalignr	xmm4, xmm0, xmm3, 8
         ; iter_20: 2 - 2
         xor	ecx, edx
@@ -4090,24 +4090,24 @@ L_SM3_AVX1len_start:
         add	r11d, ecx
         add	r15d, edx
         mov	ebx, r15d
-        roll	r15d, 8
-        roll	r13d, 9
+        rol	r15d, 8
+        rol	r13d, 9
         xor	r15d, ebx
-        roll	r9d, 19
-        roll	r15d, 9
+        rol	r9d, 19
+        rol	r15d, 9
         xor	r15d, ebx
         vpxor	xmm10, xmm1, xmm10
         ; iter_21: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+168]
         mov	ecx, r11d
         add	edx, r15d
-        roll	ecx, 12
+        rol	ecx, 12
         vpshufd	xmm4, xmm0, 249
         ; iter_21: 1 - 2
         mov	eax, DWORD PTR [rsp+100]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+84]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -4137,27 +4137,27 @@ L_SM3_AVX1len_start:
         add	r10d, ecx
         add	r14d, edx
         mov	ebx, r14d
-        roll	r14d, 8
+        rol	r14d, 8
         vpslld	xmm6, xmm4, 23
         vpsrld	xmm5, xmm4, 9
         ; iter_21: 7 - 7
-        roll	r12d, 9
+        rol	r12d, 9
         xor	r14d, ebx
-        roll	r8d, 19
-        roll	r14d, 9
+        rol	r8d, 19
+        rol	r14d, 9
         xor	r14d, ebx
         ; iter_22: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+176]
         mov	ecx, r10d
         add	edx, r14d
-        roll	ecx, 12
+        rol	ecx, 12
         vpor	xmm8, xmm7, xmm8
         vpor	xmm6, xmm5, xmm6
         ; iter_22: 1 - 1
         mov	eax, DWORD PTR [rsp+104]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+88]
-        roll	edx, 7
+        rol	edx, 7
         vpxor	xmm8, xmm6, xmm8
         vpxor	xmm4, xmm9, xmm4
         ; iter_22: 2 - 2
@@ -4187,27 +4187,27 @@ L_SM3_AVX1len_start:
         add	r9d, ecx
         add	r13d, edx
         mov	ebx, r13d
-        roll	r13d, 8
+        rol	r13d, 8
         vpor	xmm4, xmm5, xmm4
         ; iter_22: 7 - 7
-        roll	r11d, 9
+        rol	r11d, 9
         xor	r13d, ebx
-        roll	r15d, 19
-        roll	r13d, 9
+        rol	r15d, 19
+        rol	r13d, 9
         xor	r13d, ebx
         vpxor	xmm10, xmm4, xmm10
         ; iter_23: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+184]
         mov	ecx, r9d
         add	edx, r13d
-        roll	ecx, 12
+        rol	ecx, 12
         vpslld	xmm7, xmm10, 15
         vpsrld	xmm6, xmm10, 17
         ; iter_23: 1 - 1
         mov	eax, DWORD PTR [rsp+108]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+92]
-        roll	edx, 7
+        rol	edx, 7
         vpslld	xmm5, xmm10, 23
         vpsrld	xmm4, xmm10, 9
         ; iter_23: 2 - 2
@@ -4240,12 +4240,12 @@ L_SM3_AVX1len_start:
         add	r8d, ecx
         add	r12d, edx
         mov	ebx, r12d
-        roll	r12d, 8
+        rol	r12d, 8
         ; iter_23: 7 - 7
-        roll	r10d, 9
+        rol	r10d, 9
         xor	r12d, ebx
-        roll	r14d, 19
-        roll	r12d, 9
+        rol	r14d, 19
+        rol	r12d, 9
         xor	r12d, ebx
         ; msg_sched done: 20-23
         ; x2_to_w: 32
@@ -4256,13 +4256,13 @@ L_SM3_AVX1len_start:
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+192]
         mov	ecx, r8d
         add	edx, r12d
-        roll	ecx, 12
+        rol	ecx, 12
         vpalignr	xmm5, xmm3, xmm2, 12
         ; iter_24: 1 - 1
         mov	eax, DWORD PTR [rsp+112]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+96]
-        roll	edx, 7
+        rol	edx, 7
         vpalignr	xmm4, xmm1, xmm0, 8
         ; iter_24: 2 - 2
         xor	ecx, edx
@@ -4293,24 +4293,24 @@ L_SM3_AVX1len_start:
         add	r15d, ecx
         add	r11d, edx
         mov	ebx, r11d
-        roll	r11d, 8
-        roll	r9d, 9
+        rol	r11d, 8
+        rol	r9d, 9
         xor	r11d, ebx
-        roll	r13d, 19
-        roll	r11d, 9
+        rol	r13d, 19
+        rol	r11d, 9
         xor	r11d, ebx
         vpxor	xmm10, xmm2, xmm10
         ; iter_25: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+200]
         mov	ecx, r15d
         add	edx, r11d
-        roll	ecx, 12
+        rol	ecx, 12
         vpshufd	xmm4, xmm1, 249
         ; iter_25: 1 - 2
         mov	eax, DWORD PTR [rsp+116]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+100]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -4340,27 +4340,27 @@ L_SM3_AVX1len_start:
         add	r14d, ecx
         add	r10d, edx
         mov	ebx, r10d
-        roll	r10d, 8
+        rol	r10d, 8
         vpslld	xmm6, xmm4, 23
         vpsrld	xmm5, xmm4, 9
         ; iter_25: 7 - 7
-        roll	r8d, 9
+        rol	r8d, 9
         xor	r10d, ebx
-        roll	r12d, 19
-        roll	r10d, 9
+        rol	r12d, 19
+        rol	r10d, 9
         xor	r10d, ebx
         ; iter_26: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+208]
         mov	ecx, r14d
         add	edx, r10d
-        roll	ecx, 12
+        rol	ecx, 12
         vpor	xmm8, xmm7, xmm8
         vpor	xmm6, xmm5, xmm6
         ; iter_26: 1 - 1
         mov	eax, DWORD PTR [rsp+120]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+104]
-        roll	edx, 7
+        rol	edx, 7
         vpxor	xmm8, xmm6, xmm8
         vpxor	xmm4, xmm9, xmm4
         ; iter_26: 2 - 2
@@ -4390,27 +4390,27 @@ L_SM3_AVX1len_start:
         add	r13d, ecx
         add	r9d, edx
         mov	ebx, r9d
-        roll	r9d, 8
+        rol	r9d, 8
         vpor	xmm4, xmm5, xmm4
         ; iter_26: 7 - 7
-        roll	r15d, 9
+        rol	r15d, 9
         xor	r9d, ebx
-        roll	r11d, 19
-        roll	r9d, 9
+        rol	r11d, 19
+        rol	r9d, 9
         xor	r9d, ebx
         vpxor	xmm10, xmm4, xmm10
         ; iter_27: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+216]
         mov	ecx, r13d
         add	edx, r9d
-        roll	ecx, 12
+        rol	ecx, 12
         vpslld	xmm7, xmm10, 15
         vpsrld	xmm6, xmm10, 17
         ; iter_27: 1 - 1
         mov	eax, DWORD PTR [rsp+124]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+108]
-        roll	edx, 7
+        rol	edx, 7
         vpslld	xmm5, xmm10, 23
         vpsrld	xmm4, xmm10, 9
         ; iter_27: 2 - 2
@@ -4443,12 +4443,12 @@ L_SM3_AVX1len_start:
         add	r12d, ecx
         add	r8d, edx
         mov	ebx, r8d
-        roll	r8d, 8
+        rol	r8d, 8
         ; iter_27: 7 - 7
-        roll	r14d, 9
+        rol	r14d, 9
         xor	r8d, ebx
-        roll	r10d, 19
-        roll	r8d, 9
+        rol	r10d, 19
+        rol	r8d, 9
         xor	r8d, ebx
         ; msg_sched done: 24-27
         ; msg_sched: 28-31
@@ -4456,13 +4456,13 @@ L_SM3_AVX1len_start:
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+224]
         mov	ecx, r12d
         add	edx, r8d
-        roll	ecx, 12
+        rol	ecx, 12
         vpalignr	xmm5, xmm0, xmm3, 12
         ; iter_28: 1 - 1
         mov	eax, DWORD PTR [rsp+128]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+112]
-        roll	edx, 7
+        rol	edx, 7
         vpalignr	xmm4, xmm2, xmm1, 8
         ; iter_28: 2 - 2
         xor	ecx, edx
@@ -4493,24 +4493,24 @@ L_SM3_AVX1len_start:
         add	r11d, ecx
         add	r15d, edx
         mov	ebx, r15d
-        roll	r15d, 8
-        roll	r13d, 9
+        rol	r15d, 8
+        rol	r13d, 9
         xor	r15d, ebx
-        roll	r9d, 19
-        roll	r15d, 9
+        rol	r9d, 19
+        rol	r15d, 9
         xor	r15d, ebx
         vpxor	xmm10, xmm3, xmm10
         ; iter_29: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+232]
         mov	ecx, r11d
         add	edx, r15d
-        roll	ecx, 12
+        rol	ecx, 12
         vpshufd	xmm4, xmm2, 249
         ; iter_29: 1 - 2
         mov	eax, DWORD PTR [rsp+132]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+116]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -4540,27 +4540,27 @@ L_SM3_AVX1len_start:
         add	r10d, ecx
         add	r14d, edx
         mov	ebx, r14d
-        roll	r14d, 8
+        rol	r14d, 8
         vpslld	xmm6, xmm4, 23
         vpsrld	xmm5, xmm4, 9
         ; iter_29: 7 - 7
-        roll	r12d, 9
+        rol	r12d, 9
         xor	r14d, ebx
-        roll	r8d, 19
-        roll	r14d, 9
+        rol	r8d, 19
+        rol	r14d, 9
         xor	r14d, ebx
         ; iter_30: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+240]
         mov	ecx, r10d
         add	edx, r14d
-        roll	ecx, 12
+        rol	ecx, 12
         vpor	xmm8, xmm7, xmm8
         vpor	xmm6, xmm5, xmm6
         ; iter_30: 1 - 1
         mov	eax, DWORD PTR [rsp+136]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+120]
-        roll	edx, 7
+        rol	edx, 7
         vpxor	xmm8, xmm6, xmm8
         vpxor	xmm4, xmm9, xmm4
         ; iter_30: 2 - 2
@@ -4590,27 +4590,27 @@ L_SM3_AVX1len_start:
         add	r9d, ecx
         add	r13d, edx
         mov	ebx, r13d
-        roll	r13d, 8
+        rol	r13d, 8
         vpor	xmm4, xmm5, xmm4
         ; iter_30: 7 - 7
-        roll	r11d, 9
+        rol	r11d, 9
         xor	r13d, ebx
-        roll	r15d, 19
-        roll	r13d, 9
+        rol	r15d, 19
+        rol	r13d, 9
         xor	r13d, ebx
         vpxor	xmm10, xmm4, xmm10
         ; iter_31: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+248]
         mov	ecx, r9d
         add	edx, r13d
-        roll	ecx, 12
+        rol	ecx, 12
         vpslld	xmm7, xmm10, 15
         vpsrld	xmm6, xmm10, 17
         ; iter_31: 1 - 1
         mov	eax, DWORD PTR [rsp+140]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+124]
-        roll	edx, 7
+        rol	edx, 7
         vpslld	xmm5, xmm10, 23
         vpsrld	xmm4, xmm10, 9
         ; iter_31: 2 - 2
@@ -4643,12 +4643,12 @@ L_SM3_AVX1len_start:
         add	r8d, ecx
         add	r12d, edx
         mov	ebx, r12d
-        roll	r12d, 8
+        rol	r12d, 8
         ; iter_31: 7 - 7
-        roll	r10d, 9
+        rol	r10d, 9
         xor	r12d, ebx
-        roll	r14d, 19
-        roll	r12d, 9
+        rol	r14d, 19
+        rol	r12d, 9
         xor	r12d, ebx
         ; msg_sched done: 28-31
         ; x2_to_w: 40
@@ -4659,13 +4659,13 @@ L_SM3_AVX1len_start:
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+256]
         mov	ecx, r8d
         add	edx, r12d
-        roll	ecx, 12
+        rol	ecx, 12
         vpalignr	xmm5, xmm1, xmm0, 12
         ; iter_32: 1 - 1
         mov	eax, DWORD PTR [rsp+144]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+128]
-        roll	edx, 7
+        rol	edx, 7
         vpalignr	xmm4, xmm3, xmm2, 8
         ; iter_32: 2 - 2
         xor	ecx, edx
@@ -4696,24 +4696,24 @@ L_SM3_AVX1len_start:
         add	r15d, ecx
         add	r11d, edx
         mov	ebx, r11d
-        roll	r11d, 8
-        roll	r9d, 9
+        rol	r11d, 8
+        rol	r9d, 9
         xor	r11d, ebx
-        roll	r13d, 19
-        roll	r11d, 9
+        rol	r13d, 19
+        rol	r11d, 9
         xor	r11d, ebx
         vpxor	xmm10, xmm0, xmm10
         ; iter_33: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+264]
         mov	ecx, r15d
         add	edx, r11d
-        roll	ecx, 12
+        rol	ecx, 12
         vpshufd	xmm4, xmm3, 249
         ; iter_33: 1 - 2
         mov	eax, DWORD PTR [rsp+148]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+132]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -4743,27 +4743,27 @@ L_SM3_AVX1len_start:
         add	r14d, ecx
         add	r10d, edx
         mov	ebx, r10d
-        roll	r10d, 8
+        rol	r10d, 8
         vpslld	xmm6, xmm4, 23
         vpsrld	xmm5, xmm4, 9
         ; iter_33: 7 - 7
-        roll	r8d, 9
+        rol	r8d, 9
         xor	r10d, ebx
-        roll	r12d, 19
-        roll	r10d, 9
+        rol	r12d, 19
+        rol	r10d, 9
         xor	r10d, ebx
         ; iter_34: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+272]
         mov	ecx, r14d
         add	edx, r10d
-        roll	ecx, 12
+        rol	ecx, 12
         vpor	xmm8, xmm7, xmm8
         vpor	xmm6, xmm5, xmm6
         ; iter_34: 1 - 1
         mov	eax, DWORD PTR [rsp+152]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+136]
-        roll	edx, 7
+        rol	edx, 7
         vpxor	xmm8, xmm6, xmm8
         vpxor	xmm4, xmm9, xmm4
         ; iter_34: 2 - 2
@@ -4793,27 +4793,27 @@ L_SM3_AVX1len_start:
         add	r13d, ecx
         add	r9d, edx
         mov	ebx, r9d
-        roll	r9d, 8
+        rol	r9d, 8
         vpor	xmm4, xmm5, xmm4
         ; iter_34: 7 - 7
-        roll	r15d, 9
+        rol	r15d, 9
         xor	r9d, ebx
-        roll	r11d, 19
-        roll	r9d, 9
+        rol	r11d, 19
+        rol	r9d, 9
         xor	r9d, ebx
         vpxor	xmm10, xmm4, xmm10
         ; iter_35: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+280]
         mov	ecx, r13d
         add	edx, r9d
-        roll	ecx, 12
+        rol	ecx, 12
         vpslld	xmm7, xmm10, 15
         vpsrld	xmm6, xmm10, 17
         ; iter_35: 1 - 1
         mov	eax, DWORD PTR [rsp+156]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+140]
-        roll	edx, 7
+        rol	edx, 7
         vpslld	xmm5, xmm10, 23
         vpsrld	xmm4, xmm10, 9
         ; iter_35: 2 - 2
@@ -4846,12 +4846,12 @@ L_SM3_AVX1len_start:
         add	r12d, ecx
         add	r8d, edx
         mov	ebx, r8d
-        roll	r8d, 8
+        rol	r8d, 8
         ; iter_35: 7 - 7
-        roll	r14d, 9
+        rol	r14d, 9
         xor	r8d, ebx
-        roll	r10d, 19
-        roll	r8d, 9
+        rol	r10d, 19
+        rol	r8d, 9
         xor	r8d, ebx
         ; msg_sched done: 32-35
         ; msg_sched: 36-39
@@ -4859,13 +4859,13 @@ L_SM3_AVX1len_start:
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+288]
         mov	ecx, r12d
         add	edx, r8d
-        roll	ecx, 12
+        rol	ecx, 12
         vpalignr	xmm5, xmm2, xmm1, 12
         ; iter_36: 1 - 1
         mov	eax, DWORD PTR [rsp+160]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+144]
-        roll	edx, 7
+        rol	edx, 7
         vpalignr	xmm4, xmm0, xmm3, 8
         ; iter_36: 2 - 2
         xor	ecx, edx
@@ -4896,24 +4896,24 @@ L_SM3_AVX1len_start:
         add	r11d, ecx
         add	r15d, edx
         mov	ebx, r15d
-        roll	r15d, 8
-        roll	r13d, 9
+        rol	r15d, 8
+        rol	r13d, 9
         xor	r15d, ebx
-        roll	r9d, 19
-        roll	r15d, 9
+        rol	r9d, 19
+        rol	r15d, 9
         xor	r15d, ebx
         vpxor	xmm10, xmm1, xmm10
         ; iter_37: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+296]
         mov	ecx, r11d
         add	edx, r15d
-        roll	ecx, 12
+        rol	ecx, 12
         vpshufd	xmm4, xmm0, 249
         ; iter_37: 1 - 2
         mov	eax, DWORD PTR [rsp+164]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+148]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -4943,27 +4943,27 @@ L_SM3_AVX1len_start:
         add	r10d, ecx
         add	r14d, edx
         mov	ebx, r14d
-        roll	r14d, 8
+        rol	r14d, 8
         vpslld	xmm6, xmm4, 23
         vpsrld	xmm5, xmm4, 9
         ; iter_37: 7 - 7
-        roll	r12d, 9
+        rol	r12d, 9
         xor	r14d, ebx
-        roll	r8d, 19
-        roll	r14d, 9
+        rol	r8d, 19
+        rol	r14d, 9
         xor	r14d, ebx
         ; iter_38: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+304]
         mov	ecx, r10d
         add	edx, r14d
-        roll	ecx, 12
+        rol	ecx, 12
         vpor	xmm8, xmm7, xmm8
         vpor	xmm6, xmm5, xmm6
         ; iter_38: 1 - 1
         mov	eax, DWORD PTR [rsp+168]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+152]
-        roll	edx, 7
+        rol	edx, 7
         vpxor	xmm8, xmm6, xmm8
         vpxor	xmm4, xmm9, xmm4
         ; iter_38: 2 - 2
@@ -4993,27 +4993,27 @@ L_SM3_AVX1len_start:
         add	r9d, ecx
         add	r13d, edx
         mov	ebx, r13d
-        roll	r13d, 8
+        rol	r13d, 8
         vpor	xmm4, xmm5, xmm4
         ; iter_38: 7 - 7
-        roll	r11d, 9
+        rol	r11d, 9
         xor	r13d, ebx
-        roll	r15d, 19
-        roll	r13d, 9
+        rol	r15d, 19
+        rol	r13d, 9
         xor	r13d, ebx
         vpxor	xmm10, xmm4, xmm10
         ; iter_39: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+312]
         mov	ecx, r9d
         add	edx, r13d
-        roll	ecx, 12
+        rol	ecx, 12
         vpslld	xmm7, xmm10, 15
         vpsrld	xmm6, xmm10, 17
         ; iter_39: 1 - 1
         mov	eax, DWORD PTR [rsp+172]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+156]
-        roll	edx, 7
+        rol	edx, 7
         vpslld	xmm5, xmm10, 23
         vpsrld	xmm4, xmm10, 9
         ; iter_39: 2 - 2
@@ -5046,12 +5046,12 @@ L_SM3_AVX1len_start:
         add	r8d, ecx
         add	r12d, edx
         mov	ebx, r12d
-        roll	r12d, 8
+        rol	r12d, 8
         ; iter_39: 7 - 7
-        roll	r10d, 9
+        rol	r10d, 9
         xor	r12d, ebx
-        roll	r14d, 19
-        roll	r12d, 9
+        rol	r14d, 19
+        rol	r12d, 9
         xor	r12d, ebx
         ; msg_sched done: 36-39
         ; x2_to_w: 48
@@ -5062,13 +5062,13 @@ L_SM3_AVX1len_start:
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+320]
         mov	ecx, r8d
         add	edx, r12d
-        roll	ecx, 12
+        rol	ecx, 12
         vpalignr	xmm5, xmm3, xmm2, 12
         ; iter_40: 1 - 1
         mov	eax, DWORD PTR [rsp+176]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+160]
-        roll	edx, 7
+        rol	edx, 7
         vpalignr	xmm4, xmm1, xmm0, 8
         ; iter_40: 2 - 2
         xor	ecx, edx
@@ -5099,24 +5099,24 @@ L_SM3_AVX1len_start:
         add	r15d, ecx
         add	r11d, edx
         mov	ebx, r11d
-        roll	r11d, 8
-        roll	r9d, 9
+        rol	r11d, 8
+        rol	r9d, 9
         xor	r11d, ebx
-        roll	r13d, 19
-        roll	r11d, 9
+        rol	r13d, 19
+        rol	r11d, 9
         xor	r11d, ebx
         vpxor	xmm10, xmm2, xmm10
         ; iter_41: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+328]
         mov	ecx, r15d
         add	edx, r11d
-        roll	ecx, 12
+        rol	ecx, 12
         vpshufd	xmm4, xmm1, 249
         ; iter_41: 1 - 2
         mov	eax, DWORD PTR [rsp+180]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+164]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -5146,27 +5146,27 @@ L_SM3_AVX1len_start:
         add	r14d, ecx
         add	r10d, edx
         mov	ebx, r10d
-        roll	r10d, 8
+        rol	r10d, 8
         vpslld	xmm6, xmm4, 23
         vpsrld	xmm5, xmm4, 9
         ; iter_41: 7 - 7
-        roll	r8d, 9
+        rol	r8d, 9
         xor	r10d, ebx
-        roll	r12d, 19
-        roll	r10d, 9
+        rol	r12d, 19
+        rol	r10d, 9
         xor	r10d, ebx
         ; iter_42: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+336]
         mov	ecx, r14d
         add	edx, r10d
-        roll	ecx, 12
+        rol	ecx, 12
         vpor	xmm8, xmm7, xmm8
         vpor	xmm6, xmm5, xmm6
         ; iter_42: 1 - 1
         mov	eax, DWORD PTR [rsp+184]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+168]
-        roll	edx, 7
+        rol	edx, 7
         vpxor	xmm8, xmm6, xmm8
         vpxor	xmm4, xmm9, xmm4
         ; iter_42: 2 - 2
@@ -5196,27 +5196,27 @@ L_SM3_AVX1len_start:
         add	r13d, ecx
         add	r9d, edx
         mov	ebx, r9d
-        roll	r9d, 8
+        rol	r9d, 8
         vpor	xmm4, xmm5, xmm4
         ; iter_42: 7 - 7
-        roll	r15d, 9
+        rol	r15d, 9
         xor	r9d, ebx
-        roll	r11d, 19
-        roll	r9d, 9
+        rol	r11d, 19
+        rol	r9d, 9
         xor	r9d, ebx
         vpxor	xmm10, xmm4, xmm10
         ; iter_43: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+344]
         mov	ecx, r13d
         add	edx, r9d
-        roll	ecx, 12
+        rol	ecx, 12
         vpslld	xmm7, xmm10, 15
         vpsrld	xmm6, xmm10, 17
         ; iter_43: 1 - 1
         mov	eax, DWORD PTR [rsp+188]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+172]
-        roll	edx, 7
+        rol	edx, 7
         vpslld	xmm5, xmm10, 23
         vpsrld	xmm4, xmm10, 9
         ; iter_43: 2 - 2
@@ -5249,12 +5249,12 @@ L_SM3_AVX1len_start:
         add	r12d, ecx
         add	r8d, edx
         mov	ebx, r8d
-        roll	r8d, 8
+        rol	r8d, 8
         ; iter_43: 7 - 7
-        roll	r14d, 9
+        rol	r14d, 9
         xor	r8d, ebx
-        roll	r10d, 19
-        roll	r8d, 9
+        rol	r10d, 19
+        rol	r8d, 9
         xor	r8d, ebx
         ; msg_sched done: 40-43
         ; msg_sched: 44-47
@@ -5262,13 +5262,13 @@ L_SM3_AVX1len_start:
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+352]
         mov	ecx, r12d
         add	edx, r8d
-        roll	ecx, 12
+        rol	ecx, 12
         vpalignr	xmm5, xmm0, xmm3, 12
         ; iter_44: 1 - 1
         mov	eax, DWORD PTR [rsp+192]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+176]
-        roll	edx, 7
+        rol	edx, 7
         vpalignr	xmm4, xmm2, xmm1, 8
         ; iter_44: 2 - 2
         xor	ecx, edx
@@ -5299,24 +5299,24 @@ L_SM3_AVX1len_start:
         add	r11d, ecx
         add	r15d, edx
         mov	ebx, r15d
-        roll	r15d, 8
-        roll	r13d, 9
+        rol	r15d, 8
+        rol	r13d, 9
         xor	r15d, ebx
-        roll	r9d, 19
-        roll	r15d, 9
+        rol	r9d, 19
+        rol	r15d, 9
         xor	r15d, ebx
         vpxor	xmm10, xmm3, xmm10
         ; iter_45: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+360]
         mov	ecx, r11d
         add	edx, r15d
-        roll	ecx, 12
+        rol	ecx, 12
         vpshufd	xmm4, xmm2, 249
         ; iter_45: 1 - 2
         mov	eax, DWORD PTR [rsp+196]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+180]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -5346,27 +5346,27 @@ L_SM3_AVX1len_start:
         add	r10d, ecx
         add	r14d, edx
         mov	ebx, r14d
-        roll	r14d, 8
+        rol	r14d, 8
         vpslld	xmm6, xmm4, 23
         vpsrld	xmm5, xmm4, 9
         ; iter_45: 7 - 7
-        roll	r12d, 9
+        rol	r12d, 9
         xor	r14d, ebx
-        roll	r8d, 19
-        roll	r14d, 9
+        rol	r8d, 19
+        rol	r14d, 9
         xor	r14d, ebx
         ; iter_46: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+368]
         mov	ecx, r10d
         add	edx, r14d
-        roll	ecx, 12
+        rol	ecx, 12
         vpor	xmm8, xmm7, xmm8
         vpor	xmm6, xmm5, xmm6
         ; iter_46: 1 - 1
         mov	eax, DWORD PTR [rsp+200]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+184]
-        roll	edx, 7
+        rol	edx, 7
         vpxor	xmm8, xmm6, xmm8
         vpxor	xmm4, xmm9, xmm4
         ; iter_46: 2 - 2
@@ -5396,27 +5396,27 @@ L_SM3_AVX1len_start:
         add	r9d, ecx
         add	r13d, edx
         mov	ebx, r13d
-        roll	r13d, 8
+        rol	r13d, 8
         vpor	xmm4, xmm5, xmm4
         ; iter_46: 7 - 7
-        roll	r11d, 9
+        rol	r11d, 9
         xor	r13d, ebx
-        roll	r15d, 19
-        roll	r13d, 9
+        rol	r15d, 19
+        rol	r13d, 9
         xor	r13d, ebx
         vpxor	xmm10, xmm4, xmm10
         ; iter_47: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+376]
         mov	ecx, r9d
         add	edx, r13d
-        roll	ecx, 12
+        rol	ecx, 12
         vpslld	xmm7, xmm10, 15
         vpsrld	xmm6, xmm10, 17
         ; iter_47: 1 - 1
         mov	eax, DWORD PTR [rsp+204]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+188]
-        roll	edx, 7
+        rol	edx, 7
         vpslld	xmm5, xmm10, 23
         vpsrld	xmm4, xmm10, 9
         ; iter_47: 2 - 2
@@ -5449,12 +5449,12 @@ L_SM3_AVX1len_start:
         add	r8d, ecx
         add	r12d, edx
         mov	ebx, r12d
-        roll	r12d, 8
+        rol	r12d, 8
         ; iter_47: 7 - 7
-        roll	r10d, 9
+        rol	r10d, 9
         xor	r12d, ebx
-        roll	r14d, 19
-        roll	r12d, 9
+        rol	r14d, 19
+        rol	r12d, 9
         xor	r12d, ebx
         ; msg_sched done: 44-47
         ; x2_to_w: 56
@@ -5465,13 +5465,13 @@ L_SM3_AVX1len_start:
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+384]
         mov	ecx, r8d
         add	edx, r12d
-        roll	ecx, 12
+        rol	ecx, 12
         vpalignr	xmm5, xmm1, xmm0, 12
         ; iter_48: 1 - 1
         mov	eax, DWORD PTR [rsp+208]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+192]
-        roll	edx, 7
+        rol	edx, 7
         vpalignr	xmm4, xmm3, xmm2, 8
         ; iter_48: 2 - 2
         xor	ecx, edx
@@ -5502,24 +5502,24 @@ L_SM3_AVX1len_start:
         add	r15d, ecx
         add	r11d, edx
         mov	ebx, r11d
-        roll	r11d, 8
-        roll	r9d, 9
+        rol	r11d, 8
+        rol	r9d, 9
         xor	r11d, ebx
-        roll	r13d, 19
-        roll	r11d, 9
+        rol	r13d, 19
+        rol	r11d, 9
         xor	r11d, ebx
         vpxor	xmm10, xmm0, xmm10
         ; iter_49: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+392]
         mov	ecx, r15d
         add	edx, r11d
-        roll	ecx, 12
+        rol	ecx, 12
         vpshufd	xmm4, xmm3, 249
         ; iter_49: 1 - 2
         mov	eax, DWORD PTR [rsp+212]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+196]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -5549,27 +5549,27 @@ L_SM3_AVX1len_start:
         add	r14d, ecx
         add	r10d, edx
         mov	ebx, r10d
-        roll	r10d, 8
+        rol	r10d, 8
         vpslld	xmm6, xmm4, 23
         vpsrld	xmm5, xmm4, 9
         ; iter_49: 7 - 7
-        roll	r8d, 9
+        rol	r8d, 9
         xor	r10d, ebx
-        roll	r12d, 19
-        roll	r10d, 9
+        rol	r12d, 19
+        rol	r10d, 9
         xor	r10d, ebx
         ; iter_50: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+400]
         mov	ecx, r14d
         add	edx, r10d
-        roll	ecx, 12
+        rol	ecx, 12
         vpor	xmm8, xmm7, xmm8
         vpor	xmm6, xmm5, xmm6
         ; iter_50: 1 - 1
         mov	eax, DWORD PTR [rsp+216]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+200]
-        roll	edx, 7
+        rol	edx, 7
         vpxor	xmm8, xmm6, xmm8
         vpxor	xmm4, xmm9, xmm4
         ; iter_50: 2 - 2
@@ -5599,27 +5599,27 @@ L_SM3_AVX1len_start:
         add	r13d, ecx
         add	r9d, edx
         mov	ebx, r9d
-        roll	r9d, 8
+        rol	r9d, 8
         vpor	xmm4, xmm5, xmm4
         ; iter_50: 7 - 7
-        roll	r15d, 9
+        rol	r15d, 9
         xor	r9d, ebx
-        roll	r11d, 19
-        roll	r9d, 9
+        rol	r11d, 19
+        rol	r9d, 9
         xor	r9d, ebx
         vpxor	xmm10, xmm4, xmm10
         ; iter_51: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+408]
         mov	ecx, r13d
         add	edx, r9d
-        roll	ecx, 12
+        rol	ecx, 12
         vpslld	xmm7, xmm10, 15
         vpsrld	xmm6, xmm10, 17
         ; iter_51: 1 - 1
         mov	eax, DWORD PTR [rsp+220]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+204]
-        roll	edx, 7
+        rol	edx, 7
         vpslld	xmm5, xmm10, 23
         vpsrld	xmm4, xmm10, 9
         ; iter_51: 2 - 2
@@ -5652,23 +5652,23 @@ L_SM3_AVX1len_start:
         add	r12d, ecx
         add	r8d, edx
         mov	ebx, r8d
-        roll	r8d, 8
+        rol	r8d, 8
         ; iter_51: 7 - 7
-        roll	r14d, 9
+        rol	r14d, 9
         xor	r8d, ebx
-        roll	r10d, 19
-        roll	r8d, 9
+        rol	r10d, 19
+        rol	r8d, 9
         xor	r8d, ebx
         ; msg_sched done: 48-51
         ; iter_52: 0 - 7
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+416]
         mov	ecx, r12d
         add	edx, r8d
-        roll	ecx, 12
+        rol	ecx, 12
         mov	eax, DWORD PTR [rsp+224]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+208]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -5688,21 +5688,21 @@ L_SM3_AVX1len_start:
         add	r11d, ecx
         add	r15d, edx
         mov	ebx, r15d
-        roll	r15d, 8
-        roll	r13d, 9
+        rol	r15d, 8
+        rol	r13d, 9
         xor	r15d, ebx
-        roll	r9d, 19
-        roll	r15d, 9
+        rol	r9d, 19
+        rol	r15d, 9
         xor	r15d, ebx
         ; iter_53: 0 - 7
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+424]
         mov	ecx, r11d
         add	edx, r15d
-        roll	ecx, 12
+        rol	ecx, 12
         mov	eax, DWORD PTR [rsp+228]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+212]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -5722,21 +5722,21 @@ L_SM3_AVX1len_start:
         add	r10d, ecx
         add	r14d, edx
         mov	ebx, r14d
-        roll	r14d, 8
-        roll	r12d, 9
+        rol	r14d, 8
+        rol	r12d, 9
         xor	r14d, ebx
-        roll	r8d, 19
-        roll	r14d, 9
+        rol	r8d, 19
+        rol	r14d, 9
         xor	r14d, ebx
         ; iter_54: 0 - 7
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+432]
         mov	ecx, r10d
         add	edx, r14d
-        roll	ecx, 12
+        rol	ecx, 12
         mov	eax, DWORD PTR [rsp+232]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+216]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -5756,21 +5756,21 @@ L_SM3_AVX1len_start:
         add	r9d, ecx
         add	r13d, edx
         mov	ebx, r13d
-        roll	r13d, 8
-        roll	r11d, 9
+        rol	r13d, 8
+        rol	r11d, 9
         xor	r13d, ebx
-        roll	r15d, 19
-        roll	r13d, 9
+        rol	r15d, 19
+        rol	r13d, 9
         xor	r13d, ebx
         ; iter_55: 0 - 7
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+440]
         mov	ecx, r9d
         add	edx, r13d
-        roll	ecx, 12
+        rol	ecx, 12
         mov	eax, DWORD PTR [rsp+236]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+220]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -5790,11 +5790,11 @@ L_SM3_AVX1len_start:
         add	r8d, ecx
         add	r12d, edx
         mov	ebx, r12d
-        roll	r12d, 8
-        roll	r10d, 9
+        rol	r12d, 8
+        rol	r10d, 9
         xor	r12d, ebx
-        roll	r14d, 19
-        roll	r12d, 9
+        rol	r14d, 19
+        rol	r12d, 9
         xor	r12d, ebx
         ; x0_to_w: 64
         vmovdqu	OWORD PTR [rsp+256], xmm0
@@ -5802,11 +5802,11 @@ L_SM3_AVX1len_start:
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+448]
         mov	ecx, r8d
         add	edx, r12d
-        roll	ecx, 12
+        rol	ecx, 12
         mov	eax, DWORD PTR [rsp+240]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+224]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -5826,21 +5826,21 @@ L_SM3_AVX1len_start:
         add	r15d, ecx
         add	r11d, edx
         mov	ebx, r11d
-        roll	r11d, 8
-        roll	r9d, 9
+        rol	r11d, 8
+        rol	r9d, 9
         xor	r11d, ebx
-        roll	r13d, 19
-        roll	r11d, 9
+        rol	r13d, 19
+        rol	r11d, 9
         xor	r11d, ebx
         ; iter_57: 0 - 7
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+456]
         mov	ecx, r15d
         add	edx, r11d
-        roll	ecx, 12
+        rol	ecx, 12
         mov	eax, DWORD PTR [rsp+244]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+228]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -5860,21 +5860,21 @@ L_SM3_AVX1len_start:
         add	r14d, ecx
         add	r10d, edx
         mov	ebx, r10d
-        roll	r10d, 8
-        roll	r8d, 9
+        rol	r10d, 8
+        rol	r8d, 9
         xor	r10d, ebx
-        roll	r12d, 19
-        roll	r10d, 9
+        rol	r12d, 19
+        rol	r10d, 9
         xor	r10d, ebx
         ; iter_58: 0 - 7
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+464]
         mov	ecx, r14d
         add	edx, r10d
-        roll	ecx, 12
+        rol	ecx, 12
         mov	eax, DWORD PTR [rsp+248]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+232]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -5894,21 +5894,21 @@ L_SM3_AVX1len_start:
         add	r13d, ecx
         add	r9d, edx
         mov	ebx, r9d
-        roll	r9d, 8
-        roll	r15d, 9
+        rol	r9d, 8
+        rol	r15d, 9
         xor	r9d, ebx
-        roll	r11d, 19
-        roll	r9d, 9
+        rol	r11d, 19
+        rol	r9d, 9
         xor	r9d, ebx
         ; iter_59: 0 - 7
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+472]
         mov	ecx, r13d
         add	edx, r9d
-        roll	ecx, 12
+        rol	ecx, 12
         mov	eax, DWORD PTR [rsp+252]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+236]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -5928,21 +5928,21 @@ L_SM3_AVX1len_start:
         add	r12d, ecx
         add	r8d, edx
         mov	ebx, r8d
-        roll	r8d, 8
-        roll	r14d, 9
+        rol	r8d, 8
+        rol	r14d, 9
         xor	r8d, ebx
-        roll	r10d, 19
-        roll	r8d, 9
+        rol	r10d, 19
+        rol	r8d, 9
         xor	r8d, ebx
         ; iter_60: 0 - 7
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+480]
         mov	ecx, r12d
         add	edx, r8d
-        roll	ecx, 12
+        rol	ecx, 12
         mov	eax, DWORD PTR [rsp+256]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+240]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -5962,21 +5962,21 @@ L_SM3_AVX1len_start:
         add	r11d, ecx
         add	r15d, edx
         mov	ebx, r15d
-        roll	r15d, 8
-        roll	r13d, 9
+        rol	r15d, 8
+        rol	r13d, 9
         xor	r15d, ebx
-        roll	r9d, 19
-        roll	r15d, 9
+        rol	r9d, 19
+        rol	r15d, 9
         xor	r15d, ebx
         ; iter_61: 0 - 7
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+488]
         mov	ecx, r11d
         add	edx, r15d
-        roll	ecx, 12
+        rol	ecx, 12
         mov	eax, DWORD PTR [rsp+260]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+244]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -5996,21 +5996,21 @@ L_SM3_AVX1len_start:
         add	r10d, ecx
         add	r14d, edx
         mov	ebx, r14d
-        roll	r14d, 8
-        roll	r12d, 9
+        rol	r14d, 8
+        rol	r12d, 9
         xor	r14d, ebx
-        roll	r8d, 19
-        roll	r14d, 9
+        rol	r8d, 19
+        rol	r14d, 9
         xor	r14d, ebx
         ; iter_62: 0 - 7
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+496]
         mov	ecx, r10d
         add	edx, r14d
-        roll	ecx, 12
+        rol	ecx, 12
         mov	eax, DWORD PTR [rsp+264]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+248]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -6030,21 +6030,21 @@ L_SM3_AVX1len_start:
         add	r9d, ecx
         add	r13d, edx
         mov	ebx, r13d
-        roll	r13d, 8
-        roll	r11d, 9
+        rol	r13d, 8
+        rol	r11d, 9
         xor	r13d, ebx
-        roll	r15d, 19
-        roll	r13d, 9
+        rol	r15d, 19
+        rol	r13d, 9
         xor	r13d, ebx
         ; iter_63: 0 - 7
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_t+504]
         mov	ecx, r9d
         add	edx, r13d
-        roll	ecx, 12
+        rol	ecx, 12
         mov	eax, DWORD PTR [rsp+268]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+252]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -6064,11 +6064,11 @@ L_SM3_AVX1len_start:
         add	r8d, ecx
         add	r12d, edx
         mov	ebx, r12d
-        roll	r12d, 8
-        roll	r10d, 9
+        rol	r12d, 8
+        rol	r10d, 9
         xor	r12d, ebx
-        roll	r14d, 19
-        roll	r12d, 9
+        rol	r14d, 19
+        rol	r12d, 9
         xor	r12d, ebx
         xor	r8d, DWORD PTR [rdi]
         xor	r9d, DWORD PTR [rdi+4]
@@ -6079,7 +6079,7 @@ L_SM3_AVX1len_start:
         xor	r14d, DWORD PTR [rdi+24]
         xor	r15d, DWORD PTR [rdi+28]
         add	rbp, 64
-        subl	esi, 64
+        sub	esi, 64
         mov	DWORD PTR [rdi], r8d
         mov	DWORD PTR [rdi+4], r9d
         mov	DWORD PTR [rdi+8], r10d
@@ -6146,14 +6146,14 @@ sm3_compress_avx1_rorx PROC
         ; msg_sched: 0-3
         ; iter_0: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t]
-        rorxl	ecx, r8d, 20
+        rorx	ecx, r8d, 20
         add	edx, r12d
         vpalignr	xmm5, xmm1, xmm0, 12
         ; iter_0: 1 - 1
         mov	eax, DWORD PTR [rsp+16]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp]
-        roll	edx, 7
+        rol	edx, 7
         vpalignr	xmm4, xmm3, xmm2, 8
         ; iter_0: 2 - 2
         xor	ecx, edx
@@ -6177,25 +6177,25 @@ sm3_compress_avx1_rorx PROC
         ; iter_0: 5 - 5
         add	r15d, ecx
         add	r11d, edx
-        rorxl	ebx, r11d, 15
+        rorx	ebx, r11d, 15
         vpalignr	xmm10, xmm2, xmm1, 12
         ; iter_0: 6 - 7
-        rorxl	eax, r11d, 23
-        roll	r9d, 9
+        rorx	eax, r11d, 23
+        rol	r9d, 9
         xor	r11d, ebx
-        roll	r13d, 19
+        rol	r13d, 19
         xor	r11d, eax
         vpxor	xmm10, xmm0, xmm10
         ; iter_1: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+8]
-        rorxl	ecx, r15d, 20
+        rorx	ecx, r15d, 20
         add	edx, r11d
         vpshufd	xmm4, xmm3, 249
         ; iter_1: 1 - 2
         mov	eax, DWORD PTR [rsp+20]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+4]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -6217,21 +6217,21 @@ sm3_compress_avx1_rorx PROC
         ; iter_1: 5 - 5
         add	r14d, ecx
         add	r10d, edx
-        rorxl	ebx, r10d, 15
+        rorx	ebx, r10d, 15
         vpslld	xmm8, xmm4, 15
         vpsrld	xmm7, xmm4, 17
         ; iter_1: 6 - 6
-        rorxl	eax, r10d, 23
-        roll	r8d, 9
+        rorx	eax, r10d, 23
+        rol	r8d, 9
         xor	r10d, ebx
         vpslld	xmm6, xmm4, 23
         vpsrld	xmm5, xmm4, 9
         ; iter_1: 7 - 7
-        roll	r12d, 19
+        rol	r12d, 19
         xor	r10d, eax
         ; iter_2: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+16]
-        rorxl	ecx, r14d, 20
+        rorx	ecx, r14d, 20
         add	edx, r10d
         vpor	xmm8, xmm7, xmm8
         vpor	xmm6, xmm5, xmm6
@@ -6239,7 +6239,7 @@ sm3_compress_avx1_rorx PROC
         mov	eax, DWORD PTR [rsp+24]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+8]
-        roll	edx, 7
+        rol	edx, 7
         vpxor	xmm8, xmm6, xmm8
         vpxor	xmm4, xmm9, xmm4
         ; iter_2: 2 - 2
@@ -6261,21 +6261,21 @@ sm3_compress_avx1_rorx PROC
         ; iter_2: 5 - 5
         add	r13d, ecx
         add	r9d, edx
-        rorxl	ebx, r9d, 15
+        rorx	ebx, r9d, 15
         vpslld	xmm5, xmm4, 15
         vpsrld	xmm4, xmm4, 17
         ; iter_2: 6 - 6
-        rorxl	eax, r9d, 23
-        roll	r15d, 9
+        rorx	eax, r9d, 23
+        rol	r15d, 9
         xor	r9d, ebx
         vpor	xmm4, xmm5, xmm4
         ; iter_2: 7 - 7
-        roll	r11d, 19
+        rol	r11d, 19
         xor	r9d, eax
         vpxor	xmm10, xmm4, xmm10
         ; iter_3: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+24]
-        rorxl	ecx, r13d, 20
+        rorx	ecx, r13d, 20
         add	edx, r9d
         vpslld	xmm7, xmm10, 15
         vpsrld	xmm6, xmm10, 17
@@ -6283,7 +6283,7 @@ sm3_compress_avx1_rorx PROC
         mov	eax, DWORD PTR [rsp+28]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+12]
-        roll	edx, 7
+        rol	edx, 7
         vpslld	xmm5, xmm10, 23
         vpsrld	xmm4, xmm10, 9
         ; iter_3: 2 - 2
@@ -6309,27 +6309,27 @@ sm3_compress_avx1_rorx PROC
         ; iter_3: 5 - 5
         add	r12d, ecx
         add	r8d, edx
-        rorxl	ebx, r8d, 15
+        rorx	ebx, r8d, 15
         vpblendw	xmm0, xmm8, xmm10, 192
         ; iter_3: 6 - 6
-        rorxl	eax, r8d, 23
-        roll	r14d, 9
+        rorx	eax, r8d, 23
+        rol	r14d, 9
         xor	r8d, ebx
         ; iter_3: 7 - 7
-        roll	r10d, 19
+        rol	r10d, 19
         xor	r8d, eax
         ; msg_sched done: 0-3
         ; msg_sched: 4-7
         ; iter_4: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+32]
-        rorxl	ecx, r12d, 20
+        rorx	ecx, r12d, 20
         add	edx, r8d
         vpalignr	xmm5, xmm2, xmm1, 12
         ; iter_4: 1 - 1
         mov	eax, DWORD PTR [rsp+32]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+16]
-        roll	edx, 7
+        rol	edx, 7
         vpalignr	xmm4, xmm0, xmm3, 8
         ; iter_4: 2 - 2
         xor	ecx, edx
@@ -6353,25 +6353,25 @@ sm3_compress_avx1_rorx PROC
         ; iter_4: 5 - 5
         add	r11d, ecx
         add	r15d, edx
-        rorxl	ebx, r15d, 15
+        rorx	ebx, r15d, 15
         vpalignr	xmm10, xmm3, xmm2, 12
         ; iter_4: 6 - 7
-        rorxl	eax, r15d, 23
-        roll	r13d, 9
+        rorx	eax, r15d, 23
+        rol	r13d, 9
         xor	r15d, ebx
-        roll	r9d, 19
+        rol	r9d, 19
         xor	r15d, eax
         vpxor	xmm10, xmm1, xmm10
         ; iter_5: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+40]
-        rorxl	ecx, r11d, 20
+        rorx	ecx, r11d, 20
         add	edx, r15d
         vpshufd	xmm4, xmm0, 249
         ; iter_5: 1 - 2
         mov	eax, DWORD PTR [rsp+36]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+20]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -6393,21 +6393,21 @@ sm3_compress_avx1_rorx PROC
         ; iter_5: 5 - 5
         add	r10d, ecx
         add	r14d, edx
-        rorxl	ebx, r14d, 15
+        rorx	ebx, r14d, 15
         vpslld	xmm8, xmm4, 15
         vpsrld	xmm7, xmm4, 17
         ; iter_5: 6 - 6
-        rorxl	eax, r14d, 23
-        roll	r12d, 9
+        rorx	eax, r14d, 23
+        rol	r12d, 9
         xor	r14d, ebx
         vpslld	xmm6, xmm4, 23
         vpsrld	xmm5, xmm4, 9
         ; iter_5: 7 - 7
-        roll	r8d, 19
+        rol	r8d, 19
         xor	r14d, eax
         ; iter_6: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+48]
-        rorxl	ecx, r10d, 20
+        rorx	ecx, r10d, 20
         add	edx, r14d
         vpor	xmm8, xmm7, xmm8
         vpor	xmm6, xmm5, xmm6
@@ -6415,7 +6415,7 @@ sm3_compress_avx1_rorx PROC
         mov	eax, DWORD PTR [rsp+40]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+24]
-        roll	edx, 7
+        rol	edx, 7
         vpxor	xmm8, xmm6, xmm8
         vpxor	xmm4, xmm9, xmm4
         ; iter_6: 2 - 2
@@ -6437,21 +6437,21 @@ sm3_compress_avx1_rorx PROC
         ; iter_6: 5 - 5
         add	r9d, ecx
         add	r13d, edx
-        rorxl	ebx, r13d, 15
+        rorx	ebx, r13d, 15
         vpslld	xmm5, xmm4, 15
         vpsrld	xmm4, xmm4, 17
         ; iter_6: 6 - 6
-        rorxl	eax, r13d, 23
-        roll	r11d, 9
+        rorx	eax, r13d, 23
+        rol	r11d, 9
         xor	r13d, ebx
         vpor	xmm4, xmm5, xmm4
         ; iter_6: 7 - 7
-        roll	r15d, 19
+        rol	r15d, 19
         xor	r13d, eax
         vpxor	xmm10, xmm4, xmm10
         ; iter_7: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+56]
-        rorxl	ecx, r9d, 20
+        rorx	ecx, r9d, 20
         add	edx, r13d
         vpslld	xmm7, xmm10, 15
         vpsrld	xmm6, xmm10, 17
@@ -6459,7 +6459,7 @@ sm3_compress_avx1_rorx PROC
         mov	eax, DWORD PTR [rsp+44]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+28]
-        roll	edx, 7
+        rol	edx, 7
         vpslld	xmm5, xmm10, 23
         vpsrld	xmm4, xmm10, 9
         ; iter_7: 2 - 2
@@ -6485,14 +6485,14 @@ sm3_compress_avx1_rorx PROC
         ; iter_7: 5 - 5
         add	r8d, ecx
         add	r12d, edx
-        rorxl	ebx, r12d, 15
+        rorx	ebx, r12d, 15
         vpblendw	xmm1, xmm8, xmm10, 192
         ; iter_7: 6 - 6
-        rorxl	eax, r12d, 23
-        roll	r10d, 9
+        rorx	eax, r12d, 23
+        rol	r10d, 9
         xor	r12d, ebx
         ; iter_7: 7 - 7
-        roll	r14d, 19
+        rol	r14d, 19
         xor	r12d, eax
         ; msg_sched done: 4-7
         ; x2_to_w: 16
@@ -6501,14 +6501,14 @@ sm3_compress_avx1_rorx PROC
         ; msg_sched: 8-11
         ; iter_8: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+64]
-        rorxl	ecx, r8d, 20
+        rorx	ecx, r8d, 20
         add	edx, r12d
         vpalignr	xmm5, xmm3, xmm2, 12
         ; iter_8: 1 - 1
         mov	eax, DWORD PTR [rsp+48]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+32]
-        roll	edx, 7
+        rol	edx, 7
         vpalignr	xmm4, xmm1, xmm0, 8
         ; iter_8: 2 - 2
         xor	ecx, edx
@@ -6532,25 +6532,25 @@ sm3_compress_avx1_rorx PROC
         ; iter_8: 5 - 5
         add	r15d, ecx
         add	r11d, edx
-        rorxl	ebx, r11d, 15
+        rorx	ebx, r11d, 15
         vpalignr	xmm10, xmm0, xmm3, 12
         ; iter_8: 6 - 7
-        rorxl	eax, r11d, 23
-        roll	r9d, 9
+        rorx	eax, r11d, 23
+        rol	r9d, 9
         xor	r11d, ebx
-        roll	r13d, 19
+        rol	r13d, 19
         xor	r11d, eax
         vpxor	xmm10, xmm2, xmm10
         ; iter_9: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+72]
-        rorxl	ecx, r15d, 20
+        rorx	ecx, r15d, 20
         add	edx, r11d
         vpshufd	xmm4, xmm1, 249
         ; iter_9: 1 - 2
         mov	eax, DWORD PTR [rsp+52]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+36]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -6572,21 +6572,21 @@ sm3_compress_avx1_rorx PROC
         ; iter_9: 5 - 5
         add	r14d, ecx
         add	r10d, edx
-        rorxl	ebx, r10d, 15
+        rorx	ebx, r10d, 15
         vpslld	xmm8, xmm4, 15
         vpsrld	xmm7, xmm4, 17
         ; iter_9: 6 - 6
-        rorxl	eax, r10d, 23
-        roll	r8d, 9
+        rorx	eax, r10d, 23
+        rol	r8d, 9
         xor	r10d, ebx
         vpslld	xmm6, xmm4, 23
         vpsrld	xmm5, xmm4, 9
         ; iter_9: 7 - 7
-        roll	r12d, 19
+        rol	r12d, 19
         xor	r10d, eax
         ; iter_10: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+80]
-        rorxl	ecx, r14d, 20
+        rorx	ecx, r14d, 20
         add	edx, r10d
         vpor	xmm8, xmm7, xmm8
         vpor	xmm6, xmm5, xmm6
@@ -6594,7 +6594,7 @@ sm3_compress_avx1_rorx PROC
         mov	eax, DWORD PTR [rsp+56]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+40]
-        roll	edx, 7
+        rol	edx, 7
         vpxor	xmm8, xmm6, xmm8
         vpxor	xmm4, xmm9, xmm4
         ; iter_10: 2 - 2
@@ -6616,21 +6616,21 @@ sm3_compress_avx1_rorx PROC
         ; iter_10: 5 - 5
         add	r13d, ecx
         add	r9d, edx
-        rorxl	ebx, r9d, 15
+        rorx	ebx, r9d, 15
         vpslld	xmm5, xmm4, 15
         vpsrld	xmm4, xmm4, 17
         ; iter_10: 6 - 6
-        rorxl	eax, r9d, 23
-        roll	r15d, 9
+        rorx	eax, r9d, 23
+        rol	r15d, 9
         xor	r9d, ebx
         vpor	xmm4, xmm5, xmm4
         ; iter_10: 7 - 7
-        roll	r11d, 19
+        rol	r11d, 19
         xor	r9d, eax
         vpxor	xmm10, xmm4, xmm10
         ; iter_11: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+88]
-        rorxl	ecx, r13d, 20
+        rorx	ecx, r13d, 20
         add	edx, r9d
         vpslld	xmm7, xmm10, 15
         vpsrld	xmm6, xmm10, 17
@@ -6638,7 +6638,7 @@ sm3_compress_avx1_rorx PROC
         mov	eax, DWORD PTR [rsp+60]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+44]
-        roll	edx, 7
+        rol	edx, 7
         vpslld	xmm5, xmm10, 23
         vpsrld	xmm4, xmm10, 9
         ; iter_11: 2 - 2
@@ -6664,27 +6664,27 @@ sm3_compress_avx1_rorx PROC
         ; iter_11: 5 - 5
         add	r12d, ecx
         add	r8d, edx
-        rorxl	ebx, r8d, 15
+        rorx	ebx, r8d, 15
         vpblendw	xmm2, xmm8, xmm10, 192
         ; iter_11: 6 - 6
-        rorxl	eax, r8d, 23
-        roll	r14d, 9
+        rorx	eax, r8d, 23
+        rol	r14d, 9
         xor	r8d, ebx
         ; iter_11: 7 - 7
-        roll	r10d, 19
+        rol	r10d, 19
         xor	r8d, eax
         ; msg_sched done: 8-11
         ; msg_sched: 12-15
         ; iter_12: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+96]
-        rorxl	ecx, r12d, 20
+        rorx	ecx, r12d, 20
         add	edx, r8d
         vpalignr	xmm5, xmm0, xmm3, 12
         ; iter_12: 1 - 1
         mov	eax, DWORD PTR [rsp+64]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+48]
-        roll	edx, 7
+        rol	edx, 7
         vpalignr	xmm4, xmm2, xmm1, 8
         ; iter_12: 2 - 2
         xor	ecx, edx
@@ -6708,25 +6708,25 @@ sm3_compress_avx1_rorx PROC
         ; iter_12: 5 - 5
         add	r11d, ecx
         add	r15d, edx
-        rorxl	ebx, r15d, 15
+        rorx	ebx, r15d, 15
         vpalignr	xmm10, xmm1, xmm0, 12
         ; iter_12: 6 - 7
-        rorxl	eax, r15d, 23
-        roll	r13d, 9
+        rorx	eax, r15d, 23
+        rol	r13d, 9
         xor	r15d, ebx
-        roll	r9d, 19
+        rol	r9d, 19
         xor	r15d, eax
         vpxor	xmm10, xmm3, xmm10
         ; iter_13: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+104]
-        rorxl	ecx, r11d, 20
+        rorx	ecx, r11d, 20
         add	edx, r15d
         vpshufd	xmm4, xmm2, 249
         ; iter_13: 1 - 2
         mov	eax, DWORD PTR [rsp+68]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+52]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -6748,21 +6748,21 @@ sm3_compress_avx1_rorx PROC
         ; iter_13: 5 - 5
         add	r10d, ecx
         add	r14d, edx
-        rorxl	ebx, r14d, 15
+        rorx	ebx, r14d, 15
         vpslld	xmm8, xmm4, 15
         vpsrld	xmm7, xmm4, 17
         ; iter_13: 6 - 6
-        rorxl	eax, r14d, 23
-        roll	r12d, 9
+        rorx	eax, r14d, 23
+        rol	r12d, 9
         xor	r14d, ebx
         vpslld	xmm6, xmm4, 23
         vpsrld	xmm5, xmm4, 9
         ; iter_13: 7 - 7
-        roll	r8d, 19
+        rol	r8d, 19
         xor	r14d, eax
         ; iter_14: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+112]
-        rorxl	ecx, r10d, 20
+        rorx	ecx, r10d, 20
         add	edx, r14d
         vpor	xmm8, xmm7, xmm8
         vpor	xmm6, xmm5, xmm6
@@ -6770,7 +6770,7 @@ sm3_compress_avx1_rorx PROC
         mov	eax, DWORD PTR [rsp+72]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+56]
-        roll	edx, 7
+        rol	edx, 7
         vpxor	xmm8, xmm6, xmm8
         vpxor	xmm4, xmm9, xmm4
         ; iter_14: 2 - 2
@@ -6792,21 +6792,21 @@ sm3_compress_avx1_rorx PROC
         ; iter_14: 5 - 5
         add	r9d, ecx
         add	r13d, edx
-        rorxl	ebx, r13d, 15
+        rorx	ebx, r13d, 15
         vpslld	xmm5, xmm4, 15
         vpsrld	xmm4, xmm4, 17
         ; iter_14: 6 - 6
-        rorxl	eax, r13d, 23
-        roll	r11d, 9
+        rorx	eax, r13d, 23
+        rol	r11d, 9
         xor	r13d, ebx
         vpor	xmm4, xmm5, xmm4
         ; iter_14: 7 - 7
-        roll	r15d, 19
+        rol	r15d, 19
         xor	r13d, eax
         vpxor	xmm10, xmm4, xmm10
         ; iter_15: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+120]
-        rorxl	ecx, r9d, 20
+        rorx	ecx, r9d, 20
         add	edx, r13d
         vpslld	xmm7, xmm10, 15
         vpsrld	xmm6, xmm10, 17
@@ -6814,7 +6814,7 @@ sm3_compress_avx1_rorx PROC
         mov	eax, DWORD PTR [rsp+76]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+60]
-        roll	edx, 7
+        rol	edx, 7
         vpslld	xmm5, xmm10, 23
         vpsrld	xmm4, xmm10, 9
         ; iter_15: 2 - 2
@@ -6840,14 +6840,14 @@ sm3_compress_avx1_rorx PROC
         ; iter_15: 5 - 5
         add	r8d, ecx
         add	r12d, edx
-        rorxl	ebx, r12d, 15
+        rorx	ebx, r12d, 15
         vpblendw	xmm3, xmm8, xmm10, 192
         ; iter_15: 6 - 6
-        rorxl	eax, r12d, 23
-        roll	r10d, 9
+        rorx	eax, r12d, 23
+        rol	r10d, 9
         xor	r12d, ebx
         ; iter_15: 7 - 7
-        roll	r14d, 19
+        rol	r14d, 19
         xor	r12d, eax
         ; msg_sched done: 12-15
         ; x2_to_w: 24
@@ -6856,14 +6856,14 @@ sm3_compress_avx1_rorx PROC
         ; msg_sched: 16-19
         ; iter_16: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+128]
-        rorxl	ecx, r8d, 20
+        rorx	ecx, r8d, 20
         add	edx, r12d
         mov	eax, DWORD PTR [rsp+80]
         vpalignr	xmm5, xmm1, xmm0, 12
         ; iter_16: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+64]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpalignr	xmm4, xmm3, xmm2, 8
         ; iter_16: 2 - 2
@@ -6893,23 +6893,23 @@ sm3_compress_avx1_rorx PROC
         vpalignr	xmm10, xmm2, xmm1, 12
         ; iter_16: 6 - 7
         add	r11d, edx
-        rorxl	ebx, r11d, 15
-        rorxl	eax, r11d, 23
-        roll	r9d, 9
+        rorx	ebx, r11d, 15
+        rorx	eax, r11d, 23
+        rol	r9d, 9
         xor	r11d, ebx
-        roll	r13d, 19
+        rol	r13d, 19
         xor	r11d, eax
         vpxor	xmm10, xmm0, xmm10
         ; iter_17: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+136]
-        rorxl	ecx, r15d, 20
+        rorx	ecx, r15d, 20
         add	edx, r11d
         mov	eax, DWORD PTR [rsp+84]
         vpshufd	xmm4, xmm3, 249
         ; iter_17: 1 - 2
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+68]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -6938,18 +6938,18 @@ sm3_compress_avx1_rorx PROC
         vpsrld	xmm7, xmm4, 17
         ; iter_17: 6 - 6
         add	r10d, edx
-        rorxl	ebx, r10d, 15
-        rorxl	eax, r10d, 23
-        roll	r8d, 9
+        rorx	ebx, r10d, 15
+        rorx	eax, r10d, 23
+        rol	r8d, 9
         vpslld	xmm6, xmm4, 23
         vpsrld	xmm5, xmm4, 9
         ; iter_17: 7 - 7
         xor	r10d, ebx
-        roll	r12d, 19
+        rol	r12d, 19
         xor	r10d, eax
         ; iter_18: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+144]
-        rorxl	ecx, r14d, 20
+        rorx	ecx, r14d, 20
         add	edx, r10d
         mov	eax, DWORD PTR [rsp+88]
         vpor	xmm8, xmm7, xmm8
@@ -6957,7 +6957,7 @@ sm3_compress_avx1_rorx PROC
         ; iter_18: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+72]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpxor	xmm8, xmm6, xmm8
         vpxor	xmm4, xmm9, xmm4
@@ -6986,18 +6986,18 @@ sm3_compress_avx1_rorx PROC
         vpsrld	xmm4, xmm4, 17
         ; iter_18: 6 - 6
         add	r9d, edx
-        rorxl	ebx, r9d, 15
-        rorxl	eax, r9d, 23
-        roll	r15d, 9
+        rorx	ebx, r9d, 15
+        rorx	eax, r9d, 23
+        rol	r15d, 9
         vpor	xmm4, xmm5, xmm4
         ; iter_18: 7 - 7
         xor	r9d, ebx
-        roll	r11d, 19
+        rol	r11d, 19
         xor	r9d, eax
         vpxor	xmm10, xmm4, xmm10
         ; iter_19: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+152]
-        rorxl	ecx, r13d, 20
+        rorx	ecx, r13d, 20
         add	edx, r9d
         mov	eax, DWORD PTR [rsp+92]
         vpslld	xmm7, xmm10, 15
@@ -7005,7 +7005,7 @@ sm3_compress_avx1_rorx PROC
         ; iter_19: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+76]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpslld	xmm5, xmm10, 23
         vpsrld	xmm4, xmm10, 9
@@ -7037,25 +7037,25 @@ sm3_compress_avx1_rorx PROC
         vpblendw	xmm0, xmm8, xmm10, 192
         ; iter_19: 6 - 6
         add	r8d, edx
-        rorxl	ebx, r8d, 15
-        rorxl	eax, r8d, 23
-        roll	r14d, 9
+        rorx	ebx, r8d, 15
+        rorx	eax, r8d, 23
+        rol	r14d, 9
         ; iter_19: 7 - 7
         xor	r8d, ebx
-        roll	r10d, 19
+        rol	r10d, 19
         xor	r8d, eax
         ; msg_sched done: 16-19
         ; msg_sched: 20-23
         ; iter_20: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+160]
-        rorxl	ecx, r12d, 20
+        rorx	ecx, r12d, 20
         add	edx, r8d
         mov	eax, DWORD PTR [rsp+96]
         vpalignr	xmm5, xmm2, xmm1, 12
         ; iter_20: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+80]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpalignr	xmm4, xmm0, xmm3, 8
         ; iter_20: 2 - 2
@@ -7085,23 +7085,23 @@ sm3_compress_avx1_rorx PROC
         vpalignr	xmm10, xmm3, xmm2, 12
         ; iter_20: 6 - 7
         add	r15d, edx
-        rorxl	ebx, r15d, 15
-        rorxl	eax, r15d, 23
-        roll	r13d, 9
+        rorx	ebx, r15d, 15
+        rorx	eax, r15d, 23
+        rol	r13d, 9
         xor	r15d, ebx
-        roll	r9d, 19
+        rol	r9d, 19
         xor	r15d, eax
         vpxor	xmm10, xmm1, xmm10
         ; iter_21: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+168]
-        rorxl	ecx, r11d, 20
+        rorx	ecx, r11d, 20
         add	edx, r15d
         mov	eax, DWORD PTR [rsp+100]
         vpshufd	xmm4, xmm0, 249
         ; iter_21: 1 - 2
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+84]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -7130,18 +7130,18 @@ sm3_compress_avx1_rorx PROC
         vpsrld	xmm7, xmm4, 17
         ; iter_21: 6 - 6
         add	r14d, edx
-        rorxl	ebx, r14d, 15
-        rorxl	eax, r14d, 23
-        roll	r12d, 9
+        rorx	ebx, r14d, 15
+        rorx	eax, r14d, 23
+        rol	r12d, 9
         vpslld	xmm6, xmm4, 23
         vpsrld	xmm5, xmm4, 9
         ; iter_21: 7 - 7
         xor	r14d, ebx
-        roll	r8d, 19
+        rol	r8d, 19
         xor	r14d, eax
         ; iter_22: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+176]
-        rorxl	ecx, r10d, 20
+        rorx	ecx, r10d, 20
         add	edx, r14d
         mov	eax, DWORD PTR [rsp+104]
         vpor	xmm8, xmm7, xmm8
@@ -7149,7 +7149,7 @@ sm3_compress_avx1_rorx PROC
         ; iter_22: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+88]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpxor	xmm8, xmm6, xmm8
         vpxor	xmm4, xmm9, xmm4
@@ -7178,18 +7178,18 @@ sm3_compress_avx1_rorx PROC
         vpsrld	xmm4, xmm4, 17
         ; iter_22: 6 - 6
         add	r13d, edx
-        rorxl	ebx, r13d, 15
-        rorxl	eax, r13d, 23
-        roll	r11d, 9
+        rorx	ebx, r13d, 15
+        rorx	eax, r13d, 23
+        rol	r11d, 9
         vpor	xmm4, xmm5, xmm4
         ; iter_22: 7 - 7
         xor	r13d, ebx
-        roll	r15d, 19
+        rol	r15d, 19
         xor	r13d, eax
         vpxor	xmm10, xmm4, xmm10
         ; iter_23: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+184]
-        rorxl	ecx, r9d, 20
+        rorx	ecx, r9d, 20
         add	edx, r13d
         mov	eax, DWORD PTR [rsp+108]
         vpslld	xmm7, xmm10, 15
@@ -7197,7 +7197,7 @@ sm3_compress_avx1_rorx PROC
         ; iter_23: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+92]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpslld	xmm5, xmm10, 23
         vpsrld	xmm4, xmm10, 9
@@ -7229,12 +7229,12 @@ sm3_compress_avx1_rorx PROC
         vpblendw	xmm1, xmm8, xmm10, 192
         ; iter_23: 6 - 6
         add	r12d, edx
-        rorxl	ebx, r12d, 15
-        rorxl	eax, r12d, 23
-        roll	r10d, 9
+        rorx	ebx, r12d, 15
+        rorx	eax, r12d, 23
+        rol	r10d, 9
         ; iter_23: 7 - 7
         xor	r12d, ebx
-        roll	r14d, 19
+        rol	r14d, 19
         xor	r12d, eax
         ; msg_sched done: 20-23
         ; x2_to_w: 32
@@ -7243,14 +7243,14 @@ sm3_compress_avx1_rorx PROC
         ; msg_sched: 24-27
         ; iter_24: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+192]
-        rorxl	ecx, r8d, 20
+        rorx	ecx, r8d, 20
         add	edx, r12d
         mov	eax, DWORD PTR [rsp+112]
         vpalignr	xmm5, xmm3, xmm2, 12
         ; iter_24: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+96]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpalignr	xmm4, xmm1, xmm0, 8
         ; iter_24: 2 - 2
@@ -7280,23 +7280,23 @@ sm3_compress_avx1_rorx PROC
         vpalignr	xmm10, xmm0, xmm3, 12
         ; iter_24: 6 - 7
         add	r11d, edx
-        rorxl	ebx, r11d, 15
-        rorxl	eax, r11d, 23
-        roll	r9d, 9
+        rorx	ebx, r11d, 15
+        rorx	eax, r11d, 23
+        rol	r9d, 9
         xor	r11d, ebx
-        roll	r13d, 19
+        rol	r13d, 19
         xor	r11d, eax
         vpxor	xmm10, xmm2, xmm10
         ; iter_25: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+200]
-        rorxl	ecx, r15d, 20
+        rorx	ecx, r15d, 20
         add	edx, r11d
         mov	eax, DWORD PTR [rsp+116]
         vpshufd	xmm4, xmm1, 249
         ; iter_25: 1 - 2
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+100]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -7325,18 +7325,18 @@ sm3_compress_avx1_rorx PROC
         vpsrld	xmm7, xmm4, 17
         ; iter_25: 6 - 6
         add	r10d, edx
-        rorxl	ebx, r10d, 15
-        rorxl	eax, r10d, 23
-        roll	r8d, 9
+        rorx	ebx, r10d, 15
+        rorx	eax, r10d, 23
+        rol	r8d, 9
         vpslld	xmm6, xmm4, 23
         vpsrld	xmm5, xmm4, 9
         ; iter_25: 7 - 7
         xor	r10d, ebx
-        roll	r12d, 19
+        rol	r12d, 19
         xor	r10d, eax
         ; iter_26: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+208]
-        rorxl	ecx, r14d, 20
+        rorx	ecx, r14d, 20
         add	edx, r10d
         mov	eax, DWORD PTR [rsp+120]
         vpor	xmm8, xmm7, xmm8
@@ -7344,7 +7344,7 @@ sm3_compress_avx1_rorx PROC
         ; iter_26: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+104]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpxor	xmm8, xmm6, xmm8
         vpxor	xmm4, xmm9, xmm4
@@ -7373,18 +7373,18 @@ sm3_compress_avx1_rorx PROC
         vpsrld	xmm4, xmm4, 17
         ; iter_26: 6 - 6
         add	r9d, edx
-        rorxl	ebx, r9d, 15
-        rorxl	eax, r9d, 23
-        roll	r15d, 9
+        rorx	ebx, r9d, 15
+        rorx	eax, r9d, 23
+        rol	r15d, 9
         vpor	xmm4, xmm5, xmm4
         ; iter_26: 7 - 7
         xor	r9d, ebx
-        roll	r11d, 19
+        rol	r11d, 19
         xor	r9d, eax
         vpxor	xmm10, xmm4, xmm10
         ; iter_27: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+216]
-        rorxl	ecx, r13d, 20
+        rorx	ecx, r13d, 20
         add	edx, r9d
         mov	eax, DWORD PTR [rsp+124]
         vpslld	xmm7, xmm10, 15
@@ -7392,7 +7392,7 @@ sm3_compress_avx1_rorx PROC
         ; iter_27: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+108]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpslld	xmm5, xmm10, 23
         vpsrld	xmm4, xmm10, 9
@@ -7424,25 +7424,25 @@ sm3_compress_avx1_rorx PROC
         vpblendw	xmm2, xmm8, xmm10, 192
         ; iter_27: 6 - 6
         add	r8d, edx
-        rorxl	ebx, r8d, 15
-        rorxl	eax, r8d, 23
-        roll	r14d, 9
+        rorx	ebx, r8d, 15
+        rorx	eax, r8d, 23
+        rol	r14d, 9
         ; iter_27: 7 - 7
         xor	r8d, ebx
-        roll	r10d, 19
+        rol	r10d, 19
         xor	r8d, eax
         ; msg_sched done: 24-27
         ; msg_sched: 28-31
         ; iter_28: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+224]
-        rorxl	ecx, r12d, 20
+        rorx	ecx, r12d, 20
         add	edx, r8d
         mov	eax, DWORD PTR [rsp+128]
         vpalignr	xmm5, xmm0, xmm3, 12
         ; iter_28: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+112]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpalignr	xmm4, xmm2, xmm1, 8
         ; iter_28: 2 - 2
@@ -7472,23 +7472,23 @@ sm3_compress_avx1_rorx PROC
         vpalignr	xmm10, xmm1, xmm0, 12
         ; iter_28: 6 - 7
         add	r15d, edx
-        rorxl	ebx, r15d, 15
-        rorxl	eax, r15d, 23
-        roll	r13d, 9
+        rorx	ebx, r15d, 15
+        rorx	eax, r15d, 23
+        rol	r13d, 9
         xor	r15d, ebx
-        roll	r9d, 19
+        rol	r9d, 19
         xor	r15d, eax
         vpxor	xmm10, xmm3, xmm10
         ; iter_29: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+232]
-        rorxl	ecx, r11d, 20
+        rorx	ecx, r11d, 20
         add	edx, r15d
         mov	eax, DWORD PTR [rsp+132]
         vpshufd	xmm4, xmm2, 249
         ; iter_29: 1 - 2
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+116]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -7517,18 +7517,18 @@ sm3_compress_avx1_rorx PROC
         vpsrld	xmm7, xmm4, 17
         ; iter_29: 6 - 6
         add	r14d, edx
-        rorxl	ebx, r14d, 15
-        rorxl	eax, r14d, 23
-        roll	r12d, 9
+        rorx	ebx, r14d, 15
+        rorx	eax, r14d, 23
+        rol	r12d, 9
         vpslld	xmm6, xmm4, 23
         vpsrld	xmm5, xmm4, 9
         ; iter_29: 7 - 7
         xor	r14d, ebx
-        roll	r8d, 19
+        rol	r8d, 19
         xor	r14d, eax
         ; iter_30: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+240]
-        rorxl	ecx, r10d, 20
+        rorx	ecx, r10d, 20
         add	edx, r14d
         mov	eax, DWORD PTR [rsp+136]
         vpor	xmm8, xmm7, xmm8
@@ -7536,7 +7536,7 @@ sm3_compress_avx1_rorx PROC
         ; iter_30: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+120]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpxor	xmm8, xmm6, xmm8
         vpxor	xmm4, xmm9, xmm4
@@ -7565,18 +7565,18 @@ sm3_compress_avx1_rorx PROC
         vpsrld	xmm4, xmm4, 17
         ; iter_30: 6 - 6
         add	r13d, edx
-        rorxl	ebx, r13d, 15
-        rorxl	eax, r13d, 23
-        roll	r11d, 9
+        rorx	ebx, r13d, 15
+        rorx	eax, r13d, 23
+        rol	r11d, 9
         vpor	xmm4, xmm5, xmm4
         ; iter_30: 7 - 7
         xor	r13d, ebx
-        roll	r15d, 19
+        rol	r15d, 19
         xor	r13d, eax
         vpxor	xmm10, xmm4, xmm10
         ; iter_31: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+248]
-        rorxl	ecx, r9d, 20
+        rorx	ecx, r9d, 20
         add	edx, r13d
         mov	eax, DWORD PTR [rsp+140]
         vpslld	xmm7, xmm10, 15
@@ -7584,7 +7584,7 @@ sm3_compress_avx1_rorx PROC
         ; iter_31: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+124]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpslld	xmm5, xmm10, 23
         vpsrld	xmm4, xmm10, 9
@@ -7616,12 +7616,12 @@ sm3_compress_avx1_rorx PROC
         vpblendw	xmm3, xmm8, xmm10, 192
         ; iter_31: 6 - 6
         add	r12d, edx
-        rorxl	ebx, r12d, 15
-        rorxl	eax, r12d, 23
-        roll	r10d, 9
+        rorx	ebx, r12d, 15
+        rorx	eax, r12d, 23
+        rol	r10d, 9
         ; iter_31: 7 - 7
         xor	r12d, ebx
-        roll	r14d, 19
+        rol	r14d, 19
         xor	r12d, eax
         ; msg_sched done: 28-31
         ; x2_to_w: 40
@@ -7630,14 +7630,14 @@ sm3_compress_avx1_rorx PROC
         ; msg_sched: 32-35
         ; iter_32: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+256]
-        rorxl	ecx, r8d, 20
+        rorx	ecx, r8d, 20
         add	edx, r12d
         mov	eax, DWORD PTR [rsp+144]
         vpalignr	xmm5, xmm1, xmm0, 12
         ; iter_32: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+128]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpalignr	xmm4, xmm3, xmm2, 8
         ; iter_32: 2 - 2
@@ -7667,23 +7667,23 @@ sm3_compress_avx1_rorx PROC
         vpalignr	xmm10, xmm2, xmm1, 12
         ; iter_32: 6 - 7
         add	r11d, edx
-        rorxl	ebx, r11d, 15
-        rorxl	eax, r11d, 23
-        roll	r9d, 9
+        rorx	ebx, r11d, 15
+        rorx	eax, r11d, 23
+        rol	r9d, 9
         xor	r11d, ebx
-        roll	r13d, 19
+        rol	r13d, 19
         xor	r11d, eax
         vpxor	xmm10, xmm0, xmm10
         ; iter_33: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+264]
-        rorxl	ecx, r15d, 20
+        rorx	ecx, r15d, 20
         add	edx, r11d
         mov	eax, DWORD PTR [rsp+148]
         vpshufd	xmm4, xmm3, 249
         ; iter_33: 1 - 2
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+132]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -7712,18 +7712,18 @@ sm3_compress_avx1_rorx PROC
         vpsrld	xmm7, xmm4, 17
         ; iter_33: 6 - 6
         add	r10d, edx
-        rorxl	ebx, r10d, 15
-        rorxl	eax, r10d, 23
-        roll	r8d, 9
+        rorx	ebx, r10d, 15
+        rorx	eax, r10d, 23
+        rol	r8d, 9
         vpslld	xmm6, xmm4, 23
         vpsrld	xmm5, xmm4, 9
         ; iter_33: 7 - 7
         xor	r10d, ebx
-        roll	r12d, 19
+        rol	r12d, 19
         xor	r10d, eax
         ; iter_34: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+272]
-        rorxl	ecx, r14d, 20
+        rorx	ecx, r14d, 20
         add	edx, r10d
         mov	eax, DWORD PTR [rsp+152]
         vpor	xmm8, xmm7, xmm8
@@ -7731,7 +7731,7 @@ sm3_compress_avx1_rorx PROC
         ; iter_34: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+136]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpxor	xmm8, xmm6, xmm8
         vpxor	xmm4, xmm9, xmm4
@@ -7760,18 +7760,18 @@ sm3_compress_avx1_rorx PROC
         vpsrld	xmm4, xmm4, 17
         ; iter_34: 6 - 6
         add	r9d, edx
-        rorxl	ebx, r9d, 15
-        rorxl	eax, r9d, 23
-        roll	r15d, 9
+        rorx	ebx, r9d, 15
+        rorx	eax, r9d, 23
+        rol	r15d, 9
         vpor	xmm4, xmm5, xmm4
         ; iter_34: 7 - 7
         xor	r9d, ebx
-        roll	r11d, 19
+        rol	r11d, 19
         xor	r9d, eax
         vpxor	xmm10, xmm4, xmm10
         ; iter_35: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+280]
-        rorxl	ecx, r13d, 20
+        rorx	ecx, r13d, 20
         add	edx, r9d
         mov	eax, DWORD PTR [rsp+156]
         vpslld	xmm7, xmm10, 15
@@ -7779,7 +7779,7 @@ sm3_compress_avx1_rorx PROC
         ; iter_35: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+140]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpslld	xmm5, xmm10, 23
         vpsrld	xmm4, xmm10, 9
@@ -7811,25 +7811,25 @@ sm3_compress_avx1_rorx PROC
         vpblendw	xmm0, xmm8, xmm10, 192
         ; iter_35: 6 - 6
         add	r8d, edx
-        rorxl	ebx, r8d, 15
-        rorxl	eax, r8d, 23
-        roll	r14d, 9
+        rorx	ebx, r8d, 15
+        rorx	eax, r8d, 23
+        rol	r14d, 9
         ; iter_35: 7 - 7
         xor	r8d, ebx
-        roll	r10d, 19
+        rol	r10d, 19
         xor	r8d, eax
         ; msg_sched done: 32-35
         ; msg_sched: 36-39
         ; iter_36: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+288]
-        rorxl	ecx, r12d, 20
+        rorx	ecx, r12d, 20
         add	edx, r8d
         mov	eax, DWORD PTR [rsp+160]
         vpalignr	xmm5, xmm2, xmm1, 12
         ; iter_36: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+144]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpalignr	xmm4, xmm0, xmm3, 8
         ; iter_36: 2 - 2
@@ -7859,23 +7859,23 @@ sm3_compress_avx1_rorx PROC
         vpalignr	xmm10, xmm3, xmm2, 12
         ; iter_36: 6 - 7
         add	r15d, edx
-        rorxl	ebx, r15d, 15
-        rorxl	eax, r15d, 23
-        roll	r13d, 9
+        rorx	ebx, r15d, 15
+        rorx	eax, r15d, 23
+        rol	r13d, 9
         xor	r15d, ebx
-        roll	r9d, 19
+        rol	r9d, 19
         xor	r15d, eax
         vpxor	xmm10, xmm1, xmm10
         ; iter_37: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+296]
-        rorxl	ecx, r11d, 20
+        rorx	ecx, r11d, 20
         add	edx, r15d
         mov	eax, DWORD PTR [rsp+164]
         vpshufd	xmm4, xmm0, 249
         ; iter_37: 1 - 2
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+148]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -7904,18 +7904,18 @@ sm3_compress_avx1_rorx PROC
         vpsrld	xmm7, xmm4, 17
         ; iter_37: 6 - 6
         add	r14d, edx
-        rorxl	ebx, r14d, 15
-        rorxl	eax, r14d, 23
-        roll	r12d, 9
+        rorx	ebx, r14d, 15
+        rorx	eax, r14d, 23
+        rol	r12d, 9
         vpslld	xmm6, xmm4, 23
         vpsrld	xmm5, xmm4, 9
         ; iter_37: 7 - 7
         xor	r14d, ebx
-        roll	r8d, 19
+        rol	r8d, 19
         xor	r14d, eax
         ; iter_38: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+304]
-        rorxl	ecx, r10d, 20
+        rorx	ecx, r10d, 20
         add	edx, r14d
         mov	eax, DWORD PTR [rsp+168]
         vpor	xmm8, xmm7, xmm8
@@ -7923,7 +7923,7 @@ sm3_compress_avx1_rorx PROC
         ; iter_38: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+152]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpxor	xmm8, xmm6, xmm8
         vpxor	xmm4, xmm9, xmm4
@@ -7952,18 +7952,18 @@ sm3_compress_avx1_rorx PROC
         vpsrld	xmm4, xmm4, 17
         ; iter_38: 6 - 6
         add	r13d, edx
-        rorxl	ebx, r13d, 15
-        rorxl	eax, r13d, 23
-        roll	r11d, 9
+        rorx	ebx, r13d, 15
+        rorx	eax, r13d, 23
+        rol	r11d, 9
         vpor	xmm4, xmm5, xmm4
         ; iter_38: 7 - 7
         xor	r13d, ebx
-        roll	r15d, 19
+        rol	r15d, 19
         xor	r13d, eax
         vpxor	xmm10, xmm4, xmm10
         ; iter_39: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+312]
-        rorxl	ecx, r9d, 20
+        rorx	ecx, r9d, 20
         add	edx, r13d
         mov	eax, DWORD PTR [rsp+172]
         vpslld	xmm7, xmm10, 15
@@ -7971,7 +7971,7 @@ sm3_compress_avx1_rorx PROC
         ; iter_39: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+156]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpslld	xmm5, xmm10, 23
         vpsrld	xmm4, xmm10, 9
@@ -8003,12 +8003,12 @@ sm3_compress_avx1_rorx PROC
         vpblendw	xmm1, xmm8, xmm10, 192
         ; iter_39: 6 - 6
         add	r12d, edx
-        rorxl	ebx, r12d, 15
-        rorxl	eax, r12d, 23
-        roll	r10d, 9
+        rorx	ebx, r12d, 15
+        rorx	eax, r12d, 23
+        rol	r10d, 9
         ; iter_39: 7 - 7
         xor	r12d, ebx
-        roll	r14d, 19
+        rol	r14d, 19
         xor	r12d, eax
         ; msg_sched done: 36-39
         ; x2_to_w: 48
@@ -8017,14 +8017,14 @@ sm3_compress_avx1_rorx PROC
         ; msg_sched: 40-43
         ; iter_40: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+320]
-        rorxl	ecx, r8d, 20
+        rorx	ecx, r8d, 20
         add	edx, r12d
         mov	eax, DWORD PTR [rsp+176]
         vpalignr	xmm5, xmm3, xmm2, 12
         ; iter_40: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+160]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpalignr	xmm4, xmm1, xmm0, 8
         ; iter_40: 2 - 2
@@ -8054,23 +8054,23 @@ sm3_compress_avx1_rorx PROC
         vpalignr	xmm10, xmm0, xmm3, 12
         ; iter_40: 6 - 7
         add	r11d, edx
-        rorxl	ebx, r11d, 15
-        rorxl	eax, r11d, 23
-        roll	r9d, 9
+        rorx	ebx, r11d, 15
+        rorx	eax, r11d, 23
+        rol	r9d, 9
         xor	r11d, ebx
-        roll	r13d, 19
+        rol	r13d, 19
         xor	r11d, eax
         vpxor	xmm10, xmm2, xmm10
         ; iter_41: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+328]
-        rorxl	ecx, r15d, 20
+        rorx	ecx, r15d, 20
         add	edx, r11d
         mov	eax, DWORD PTR [rsp+180]
         vpshufd	xmm4, xmm1, 249
         ; iter_41: 1 - 2
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+164]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -8099,18 +8099,18 @@ sm3_compress_avx1_rorx PROC
         vpsrld	xmm7, xmm4, 17
         ; iter_41: 6 - 6
         add	r10d, edx
-        rorxl	ebx, r10d, 15
-        rorxl	eax, r10d, 23
-        roll	r8d, 9
+        rorx	ebx, r10d, 15
+        rorx	eax, r10d, 23
+        rol	r8d, 9
         vpslld	xmm6, xmm4, 23
         vpsrld	xmm5, xmm4, 9
         ; iter_41: 7 - 7
         xor	r10d, ebx
-        roll	r12d, 19
+        rol	r12d, 19
         xor	r10d, eax
         ; iter_42: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+336]
-        rorxl	ecx, r14d, 20
+        rorx	ecx, r14d, 20
         add	edx, r10d
         mov	eax, DWORD PTR [rsp+184]
         vpor	xmm8, xmm7, xmm8
@@ -8118,7 +8118,7 @@ sm3_compress_avx1_rorx PROC
         ; iter_42: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+168]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpxor	xmm8, xmm6, xmm8
         vpxor	xmm4, xmm9, xmm4
@@ -8147,18 +8147,18 @@ sm3_compress_avx1_rorx PROC
         vpsrld	xmm4, xmm4, 17
         ; iter_42: 6 - 6
         add	r9d, edx
-        rorxl	ebx, r9d, 15
-        rorxl	eax, r9d, 23
-        roll	r15d, 9
+        rorx	ebx, r9d, 15
+        rorx	eax, r9d, 23
+        rol	r15d, 9
         vpor	xmm4, xmm5, xmm4
         ; iter_42: 7 - 7
         xor	r9d, ebx
-        roll	r11d, 19
+        rol	r11d, 19
         xor	r9d, eax
         vpxor	xmm10, xmm4, xmm10
         ; iter_43: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+344]
-        rorxl	ecx, r13d, 20
+        rorx	ecx, r13d, 20
         add	edx, r9d
         mov	eax, DWORD PTR [rsp+188]
         vpslld	xmm7, xmm10, 15
@@ -8166,7 +8166,7 @@ sm3_compress_avx1_rorx PROC
         ; iter_43: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+172]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpslld	xmm5, xmm10, 23
         vpsrld	xmm4, xmm10, 9
@@ -8198,25 +8198,25 @@ sm3_compress_avx1_rorx PROC
         vpblendw	xmm2, xmm8, xmm10, 192
         ; iter_43: 6 - 6
         add	r8d, edx
-        rorxl	ebx, r8d, 15
-        rorxl	eax, r8d, 23
-        roll	r14d, 9
+        rorx	ebx, r8d, 15
+        rorx	eax, r8d, 23
+        rol	r14d, 9
         ; iter_43: 7 - 7
         xor	r8d, ebx
-        roll	r10d, 19
+        rol	r10d, 19
         xor	r8d, eax
         ; msg_sched done: 40-43
         ; msg_sched: 44-47
         ; iter_44: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+352]
-        rorxl	ecx, r12d, 20
+        rorx	ecx, r12d, 20
         add	edx, r8d
         mov	eax, DWORD PTR [rsp+192]
         vpalignr	xmm5, xmm0, xmm3, 12
         ; iter_44: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+176]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpalignr	xmm4, xmm2, xmm1, 8
         ; iter_44: 2 - 2
@@ -8246,23 +8246,23 @@ sm3_compress_avx1_rorx PROC
         vpalignr	xmm10, xmm1, xmm0, 12
         ; iter_44: 6 - 7
         add	r15d, edx
-        rorxl	ebx, r15d, 15
-        rorxl	eax, r15d, 23
-        roll	r13d, 9
+        rorx	ebx, r15d, 15
+        rorx	eax, r15d, 23
+        rol	r13d, 9
         xor	r15d, ebx
-        roll	r9d, 19
+        rol	r9d, 19
         xor	r15d, eax
         vpxor	xmm10, xmm3, xmm10
         ; iter_45: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+360]
-        rorxl	ecx, r11d, 20
+        rorx	ecx, r11d, 20
         add	edx, r15d
         mov	eax, DWORD PTR [rsp+196]
         vpshufd	xmm4, xmm2, 249
         ; iter_45: 1 - 2
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+180]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -8291,18 +8291,18 @@ sm3_compress_avx1_rorx PROC
         vpsrld	xmm7, xmm4, 17
         ; iter_45: 6 - 6
         add	r14d, edx
-        rorxl	ebx, r14d, 15
-        rorxl	eax, r14d, 23
-        roll	r12d, 9
+        rorx	ebx, r14d, 15
+        rorx	eax, r14d, 23
+        rol	r12d, 9
         vpslld	xmm6, xmm4, 23
         vpsrld	xmm5, xmm4, 9
         ; iter_45: 7 - 7
         xor	r14d, ebx
-        roll	r8d, 19
+        rol	r8d, 19
         xor	r14d, eax
         ; iter_46: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+368]
-        rorxl	ecx, r10d, 20
+        rorx	ecx, r10d, 20
         add	edx, r14d
         mov	eax, DWORD PTR [rsp+200]
         vpor	xmm8, xmm7, xmm8
@@ -8310,7 +8310,7 @@ sm3_compress_avx1_rorx PROC
         ; iter_46: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+184]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpxor	xmm8, xmm6, xmm8
         vpxor	xmm4, xmm9, xmm4
@@ -8339,18 +8339,18 @@ sm3_compress_avx1_rorx PROC
         vpsrld	xmm4, xmm4, 17
         ; iter_46: 6 - 6
         add	r13d, edx
-        rorxl	ebx, r13d, 15
-        rorxl	eax, r13d, 23
-        roll	r11d, 9
+        rorx	ebx, r13d, 15
+        rorx	eax, r13d, 23
+        rol	r11d, 9
         vpor	xmm4, xmm5, xmm4
         ; iter_46: 7 - 7
         xor	r13d, ebx
-        roll	r15d, 19
+        rol	r15d, 19
         xor	r13d, eax
         vpxor	xmm10, xmm4, xmm10
         ; iter_47: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+376]
-        rorxl	ecx, r9d, 20
+        rorx	ecx, r9d, 20
         add	edx, r13d
         mov	eax, DWORD PTR [rsp+204]
         vpslld	xmm7, xmm10, 15
@@ -8358,7 +8358,7 @@ sm3_compress_avx1_rorx PROC
         ; iter_47: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+188]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpslld	xmm5, xmm10, 23
         vpsrld	xmm4, xmm10, 9
@@ -8390,12 +8390,12 @@ sm3_compress_avx1_rorx PROC
         vpblendw	xmm3, xmm8, xmm10, 192
         ; iter_47: 6 - 6
         add	r12d, edx
-        rorxl	ebx, r12d, 15
-        rorxl	eax, r12d, 23
-        roll	r10d, 9
+        rorx	ebx, r12d, 15
+        rorx	eax, r12d, 23
+        rol	r10d, 9
         ; iter_47: 7 - 7
         xor	r12d, ebx
-        roll	r14d, 19
+        rol	r14d, 19
         xor	r12d, eax
         ; msg_sched done: 44-47
         ; x2_to_w: 56
@@ -8404,14 +8404,14 @@ sm3_compress_avx1_rorx PROC
         ; msg_sched: 48-51
         ; iter_48: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+384]
-        rorxl	ecx, r8d, 20
+        rorx	ecx, r8d, 20
         add	edx, r12d
         mov	eax, DWORD PTR [rsp+208]
         vpalignr	xmm5, xmm1, xmm0, 12
         ; iter_48: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+192]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpalignr	xmm4, xmm3, xmm2, 8
         ; iter_48: 2 - 2
@@ -8441,23 +8441,23 @@ sm3_compress_avx1_rorx PROC
         vpalignr	xmm10, xmm2, xmm1, 12
         ; iter_48: 6 - 7
         add	r11d, edx
-        rorxl	ebx, r11d, 15
-        rorxl	eax, r11d, 23
-        roll	r9d, 9
+        rorx	ebx, r11d, 15
+        rorx	eax, r11d, 23
+        rol	r9d, 9
         xor	r11d, ebx
-        roll	r13d, 19
+        rol	r13d, 19
         xor	r11d, eax
         vpxor	xmm10, xmm0, xmm10
         ; iter_49: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+392]
-        rorxl	ecx, r15d, 20
+        rorx	ecx, r15d, 20
         add	edx, r11d
         mov	eax, DWORD PTR [rsp+212]
         vpshufd	xmm4, xmm3, 249
         ; iter_49: 1 - 2
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+196]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -8486,18 +8486,18 @@ sm3_compress_avx1_rorx PROC
         vpsrld	xmm7, xmm4, 17
         ; iter_49: 6 - 6
         add	r10d, edx
-        rorxl	ebx, r10d, 15
-        rorxl	eax, r10d, 23
-        roll	r8d, 9
+        rorx	ebx, r10d, 15
+        rorx	eax, r10d, 23
+        rol	r8d, 9
         vpslld	xmm6, xmm4, 23
         vpsrld	xmm5, xmm4, 9
         ; iter_49: 7 - 7
         xor	r10d, ebx
-        roll	r12d, 19
+        rol	r12d, 19
         xor	r10d, eax
         ; iter_50: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+400]
-        rorxl	ecx, r14d, 20
+        rorx	ecx, r14d, 20
         add	edx, r10d
         mov	eax, DWORD PTR [rsp+216]
         vpor	xmm8, xmm7, xmm8
@@ -8505,7 +8505,7 @@ sm3_compress_avx1_rorx PROC
         ; iter_50: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+200]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpxor	xmm8, xmm6, xmm8
         vpxor	xmm4, xmm9, xmm4
@@ -8534,18 +8534,18 @@ sm3_compress_avx1_rorx PROC
         vpsrld	xmm4, xmm4, 17
         ; iter_50: 6 - 6
         add	r9d, edx
-        rorxl	ebx, r9d, 15
-        rorxl	eax, r9d, 23
-        roll	r15d, 9
+        rorx	ebx, r9d, 15
+        rorx	eax, r9d, 23
+        rol	r15d, 9
         vpor	xmm4, xmm5, xmm4
         ; iter_50: 7 - 7
         xor	r9d, ebx
-        roll	r11d, 19
+        rol	r11d, 19
         xor	r9d, eax
         vpxor	xmm10, xmm4, xmm10
         ; iter_51: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+408]
-        rorxl	ecx, r13d, 20
+        rorx	ecx, r13d, 20
         add	edx, r9d
         mov	eax, DWORD PTR [rsp+220]
         vpslld	xmm7, xmm10, 15
@@ -8553,7 +8553,7 @@ sm3_compress_avx1_rorx PROC
         ; iter_51: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+204]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpslld	xmm5, xmm10, 23
         vpsrld	xmm4, xmm10, 9
@@ -8585,22 +8585,22 @@ sm3_compress_avx1_rorx PROC
         vpblendw	xmm0, xmm8, xmm10, 192
         ; iter_51: 6 - 6
         add	r8d, edx
-        rorxl	ebx, r8d, 15
-        rorxl	eax, r8d, 23
-        roll	r14d, 9
+        rorx	ebx, r8d, 15
+        rorx	eax, r8d, 23
+        rol	r14d, 9
         ; iter_51: 7 - 7
         xor	r8d, ebx
-        roll	r10d, 19
+        rol	r10d, 19
         xor	r8d, eax
         ; msg_sched done: 48-51
         ; iter_52: 0 - 7
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+416]
-        rorxl	ecx, r12d, 20
+        rorx	ecx, r12d, 20
         add	edx, r8d
         mov	eax, DWORD PTR [rsp+224]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+208]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -8619,20 +8619,20 @@ sm3_compress_avx1_rorx PROC
         add	r11d, ecx
         or	r15d, ebx
         add	r15d, edx
-        rorxl	ebx, r15d, 15
-        rorxl	eax, r15d, 23
-        roll	r13d, 9
+        rorx	ebx, r15d, 15
+        rorx	eax, r15d, 23
+        rol	r13d, 9
         xor	r15d, ebx
-        roll	r9d, 19
+        rol	r9d, 19
         xor	r15d, eax
         ; iter_53: 0 - 7
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+424]
-        rorxl	ecx, r11d, 20
+        rorx	ecx, r11d, 20
         add	edx, r15d
         mov	eax, DWORD PTR [rsp+228]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+212]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -8651,20 +8651,20 @@ sm3_compress_avx1_rorx PROC
         add	r10d, ecx
         or	r14d, ebx
         add	r14d, edx
-        rorxl	ebx, r14d, 15
-        rorxl	eax, r14d, 23
-        roll	r12d, 9
+        rorx	ebx, r14d, 15
+        rorx	eax, r14d, 23
+        rol	r12d, 9
         xor	r14d, ebx
-        roll	r8d, 19
+        rol	r8d, 19
         xor	r14d, eax
         ; iter_54: 0 - 7
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+432]
-        rorxl	ecx, r10d, 20
+        rorx	ecx, r10d, 20
         add	edx, r14d
         mov	eax, DWORD PTR [rsp+232]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+216]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -8683,20 +8683,20 @@ sm3_compress_avx1_rorx PROC
         add	r9d, ecx
         or	r13d, ebx
         add	r13d, edx
-        rorxl	ebx, r13d, 15
-        rorxl	eax, r13d, 23
-        roll	r11d, 9
+        rorx	ebx, r13d, 15
+        rorx	eax, r13d, 23
+        rol	r11d, 9
         xor	r13d, ebx
-        roll	r15d, 19
+        rol	r15d, 19
         xor	r13d, eax
         ; iter_55: 0 - 7
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+440]
-        rorxl	ecx, r9d, 20
+        rorx	ecx, r9d, 20
         add	edx, r13d
         mov	eax, DWORD PTR [rsp+236]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+220]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -8715,22 +8715,22 @@ sm3_compress_avx1_rorx PROC
         add	r8d, ecx
         or	r12d, ebx
         add	r12d, edx
-        rorxl	ebx, r12d, 15
-        rorxl	eax, r12d, 23
-        roll	r10d, 9
+        rorx	ebx, r12d, 15
+        rorx	eax, r12d, 23
+        rol	r10d, 9
         xor	r12d, ebx
-        roll	r14d, 19
+        rol	r14d, 19
         xor	r12d, eax
         ; x0_to_w: 64
         vmovdqu	OWORD PTR [rsp+256], xmm0
         ; iter_56: 0 - 7
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+448]
-        rorxl	ecx, r8d, 20
+        rorx	ecx, r8d, 20
         add	edx, r12d
         mov	eax, DWORD PTR [rsp+240]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+224]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -8749,20 +8749,20 @@ sm3_compress_avx1_rorx PROC
         add	r15d, ecx
         or	r11d, ebx
         add	r11d, edx
-        rorxl	ebx, r11d, 15
-        rorxl	eax, r11d, 23
-        roll	r9d, 9
+        rorx	ebx, r11d, 15
+        rorx	eax, r11d, 23
+        rol	r9d, 9
         xor	r11d, ebx
-        roll	r13d, 19
+        rol	r13d, 19
         xor	r11d, eax
         ; iter_57: 0 - 7
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+456]
-        rorxl	ecx, r15d, 20
+        rorx	ecx, r15d, 20
         add	edx, r11d
         mov	eax, DWORD PTR [rsp+244]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+228]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -8781,20 +8781,20 @@ sm3_compress_avx1_rorx PROC
         add	r14d, ecx
         or	r10d, ebx
         add	r10d, edx
-        rorxl	ebx, r10d, 15
-        rorxl	eax, r10d, 23
-        roll	r8d, 9
+        rorx	ebx, r10d, 15
+        rorx	eax, r10d, 23
+        rol	r8d, 9
         xor	r10d, ebx
-        roll	r12d, 19
+        rol	r12d, 19
         xor	r10d, eax
         ; iter_58: 0 - 7
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+464]
-        rorxl	ecx, r14d, 20
+        rorx	ecx, r14d, 20
         add	edx, r10d
         mov	eax, DWORD PTR [rsp+248]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+232]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -8813,20 +8813,20 @@ sm3_compress_avx1_rorx PROC
         add	r13d, ecx
         or	r9d, ebx
         add	r9d, edx
-        rorxl	ebx, r9d, 15
-        rorxl	eax, r9d, 23
-        roll	r15d, 9
+        rorx	ebx, r9d, 15
+        rorx	eax, r9d, 23
+        rol	r15d, 9
         xor	r9d, ebx
-        roll	r11d, 19
+        rol	r11d, 19
         xor	r9d, eax
         ; iter_59: 0 - 7
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+472]
-        rorxl	ecx, r13d, 20
+        rorx	ecx, r13d, 20
         add	edx, r9d
         mov	eax, DWORD PTR [rsp+252]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+236]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -8845,20 +8845,20 @@ sm3_compress_avx1_rorx PROC
         add	r12d, ecx
         or	r8d, ebx
         add	r8d, edx
-        rorxl	ebx, r8d, 15
-        rorxl	eax, r8d, 23
-        roll	r14d, 9
+        rorx	ebx, r8d, 15
+        rorx	eax, r8d, 23
+        rol	r14d, 9
         xor	r8d, ebx
-        roll	r10d, 19
+        rol	r10d, 19
         xor	r8d, eax
         ; iter_60: 0 - 7
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+480]
-        rorxl	ecx, r12d, 20
+        rorx	ecx, r12d, 20
         add	edx, r8d
         mov	eax, DWORD PTR [rsp+256]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+240]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -8877,20 +8877,20 @@ sm3_compress_avx1_rorx PROC
         add	r11d, ecx
         or	r15d, ebx
         add	r15d, edx
-        rorxl	ebx, r15d, 15
-        rorxl	eax, r15d, 23
-        roll	r13d, 9
+        rorx	ebx, r15d, 15
+        rorx	eax, r15d, 23
+        rol	r13d, 9
         xor	r15d, ebx
-        roll	r9d, 19
+        rol	r9d, 19
         xor	r15d, eax
         ; iter_61: 0 - 7
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+488]
-        rorxl	ecx, r11d, 20
+        rorx	ecx, r11d, 20
         add	edx, r15d
         mov	eax, DWORD PTR [rsp+260]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+244]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -8909,20 +8909,20 @@ sm3_compress_avx1_rorx PROC
         add	r10d, ecx
         or	r14d, ebx
         add	r14d, edx
-        rorxl	ebx, r14d, 15
-        rorxl	eax, r14d, 23
-        roll	r12d, 9
+        rorx	ebx, r14d, 15
+        rorx	eax, r14d, 23
+        rol	r12d, 9
         xor	r14d, ebx
-        roll	r8d, 19
+        rol	r8d, 19
         xor	r14d, eax
         ; iter_62: 0 - 7
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+496]
-        rorxl	ecx, r10d, 20
+        rorx	ecx, r10d, 20
         add	edx, r14d
         mov	eax, DWORD PTR [rsp+264]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+248]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -8941,20 +8941,20 @@ sm3_compress_avx1_rorx PROC
         add	r9d, ecx
         or	r13d, ebx
         add	r13d, edx
-        rorxl	ebx, r13d, 15
-        rorxl	eax, r13d, 23
-        roll	r11d, 9
+        rorx	ebx, r13d, 15
+        rorx	eax, r13d, 23
+        rol	r11d, 9
         xor	r13d, ebx
-        roll	r15d, 19
+        rol	r15d, 19
         xor	r13d, eax
         ; iter_63: 0 - 7
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+504]
-        rorxl	ecx, r9d, 20
+        rorx	ecx, r9d, 20
         add	edx, r13d
         mov	eax, DWORD PTR [rsp+268]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+252]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -8973,11 +8973,11 @@ sm3_compress_avx1_rorx PROC
         add	r8d, ecx
         or	r12d, ebx
         add	r12d, edx
-        rorxl	ebx, r12d, 15
-        rorxl	eax, r12d, 23
-        roll	r10d, 9
+        rorx	ebx, r12d, 15
+        rorx	eax, r12d, 23
+        rol	r10d, 9
         xor	r12d, ebx
-        roll	r14d, 19
+        rol	r14d, 19
         xor	r12d, eax
         xor	DWORD PTR [rdi], r8d
         xor	DWORD PTR [rdi+4], r9d
@@ -9041,14 +9041,14 @@ L_SM3_AVX1_RORXlen_start:
         ; msg_sched: 0-3
         ; iter_0: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t]
-        rorxl	ecx, r8d, 20
+        rorx	ecx, r8d, 20
         add	edx, r12d
         vpalignr	xmm5, xmm1, xmm0, 12
         ; iter_0: 1 - 1
         mov	eax, DWORD PTR [rsp+16]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp]
-        roll	edx, 7
+        rol	edx, 7
         vpalignr	xmm4, xmm3, xmm2, 8
         ; iter_0: 2 - 2
         xor	ecx, edx
@@ -9072,25 +9072,25 @@ L_SM3_AVX1_RORXlen_start:
         ; iter_0: 5 - 5
         add	r15d, ecx
         add	r11d, edx
-        rorxl	ebx, r11d, 15
+        rorx	ebx, r11d, 15
         vpalignr	xmm10, xmm2, xmm1, 12
         ; iter_0: 6 - 7
-        rorxl	eax, r11d, 23
-        roll	r9d, 9
+        rorx	eax, r11d, 23
+        rol	r9d, 9
         xor	r11d, ebx
-        roll	r13d, 19
+        rol	r13d, 19
         xor	r11d, eax
         vpxor	xmm10, xmm0, xmm10
         ; iter_1: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+8]
-        rorxl	ecx, r15d, 20
+        rorx	ecx, r15d, 20
         add	edx, r11d
         vpshufd	xmm4, xmm3, 249
         ; iter_1: 1 - 2
         mov	eax, DWORD PTR [rsp+20]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+4]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -9112,21 +9112,21 @@ L_SM3_AVX1_RORXlen_start:
         ; iter_1: 5 - 5
         add	r14d, ecx
         add	r10d, edx
-        rorxl	ebx, r10d, 15
+        rorx	ebx, r10d, 15
         vpslld	xmm8, xmm4, 15
         vpsrld	xmm7, xmm4, 17
         ; iter_1: 6 - 6
-        rorxl	eax, r10d, 23
-        roll	r8d, 9
+        rorx	eax, r10d, 23
+        rol	r8d, 9
         xor	r10d, ebx
         vpslld	xmm6, xmm4, 23
         vpsrld	xmm5, xmm4, 9
         ; iter_1: 7 - 7
-        roll	r12d, 19
+        rol	r12d, 19
         xor	r10d, eax
         ; iter_2: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+16]
-        rorxl	ecx, r14d, 20
+        rorx	ecx, r14d, 20
         add	edx, r10d
         vpor	xmm8, xmm7, xmm8
         vpor	xmm6, xmm5, xmm6
@@ -9134,7 +9134,7 @@ L_SM3_AVX1_RORXlen_start:
         mov	eax, DWORD PTR [rsp+24]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+8]
-        roll	edx, 7
+        rol	edx, 7
         vpxor	xmm8, xmm6, xmm8
         vpxor	xmm4, xmm9, xmm4
         ; iter_2: 2 - 2
@@ -9156,21 +9156,21 @@ L_SM3_AVX1_RORXlen_start:
         ; iter_2: 5 - 5
         add	r13d, ecx
         add	r9d, edx
-        rorxl	ebx, r9d, 15
+        rorx	ebx, r9d, 15
         vpslld	xmm5, xmm4, 15
         vpsrld	xmm4, xmm4, 17
         ; iter_2: 6 - 6
-        rorxl	eax, r9d, 23
-        roll	r15d, 9
+        rorx	eax, r9d, 23
+        rol	r15d, 9
         xor	r9d, ebx
         vpor	xmm4, xmm5, xmm4
         ; iter_2: 7 - 7
-        roll	r11d, 19
+        rol	r11d, 19
         xor	r9d, eax
         vpxor	xmm10, xmm4, xmm10
         ; iter_3: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+24]
-        rorxl	ecx, r13d, 20
+        rorx	ecx, r13d, 20
         add	edx, r9d
         vpslld	xmm7, xmm10, 15
         vpsrld	xmm6, xmm10, 17
@@ -9178,7 +9178,7 @@ L_SM3_AVX1_RORXlen_start:
         mov	eax, DWORD PTR [rsp+28]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+12]
-        roll	edx, 7
+        rol	edx, 7
         vpslld	xmm5, xmm10, 23
         vpsrld	xmm4, xmm10, 9
         ; iter_3: 2 - 2
@@ -9204,27 +9204,27 @@ L_SM3_AVX1_RORXlen_start:
         ; iter_3: 5 - 5
         add	r12d, ecx
         add	r8d, edx
-        rorxl	ebx, r8d, 15
+        rorx	ebx, r8d, 15
         vpblendw	xmm0, xmm8, xmm10, 192
         ; iter_3: 6 - 6
-        rorxl	eax, r8d, 23
-        roll	r14d, 9
+        rorx	eax, r8d, 23
+        rol	r14d, 9
         xor	r8d, ebx
         ; iter_3: 7 - 7
-        roll	r10d, 19
+        rol	r10d, 19
         xor	r8d, eax
         ; msg_sched done: 0-3
         ; msg_sched: 4-7
         ; iter_4: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+32]
-        rorxl	ecx, r12d, 20
+        rorx	ecx, r12d, 20
         add	edx, r8d
         vpalignr	xmm5, xmm2, xmm1, 12
         ; iter_4: 1 - 1
         mov	eax, DWORD PTR [rsp+32]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+16]
-        roll	edx, 7
+        rol	edx, 7
         vpalignr	xmm4, xmm0, xmm3, 8
         ; iter_4: 2 - 2
         xor	ecx, edx
@@ -9248,25 +9248,25 @@ L_SM3_AVX1_RORXlen_start:
         ; iter_4: 5 - 5
         add	r11d, ecx
         add	r15d, edx
-        rorxl	ebx, r15d, 15
+        rorx	ebx, r15d, 15
         vpalignr	xmm10, xmm3, xmm2, 12
         ; iter_4: 6 - 7
-        rorxl	eax, r15d, 23
-        roll	r13d, 9
+        rorx	eax, r15d, 23
+        rol	r13d, 9
         xor	r15d, ebx
-        roll	r9d, 19
+        rol	r9d, 19
         xor	r15d, eax
         vpxor	xmm10, xmm1, xmm10
         ; iter_5: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+40]
-        rorxl	ecx, r11d, 20
+        rorx	ecx, r11d, 20
         add	edx, r15d
         vpshufd	xmm4, xmm0, 249
         ; iter_5: 1 - 2
         mov	eax, DWORD PTR [rsp+36]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+20]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -9288,21 +9288,21 @@ L_SM3_AVX1_RORXlen_start:
         ; iter_5: 5 - 5
         add	r10d, ecx
         add	r14d, edx
-        rorxl	ebx, r14d, 15
+        rorx	ebx, r14d, 15
         vpslld	xmm8, xmm4, 15
         vpsrld	xmm7, xmm4, 17
         ; iter_5: 6 - 6
-        rorxl	eax, r14d, 23
-        roll	r12d, 9
+        rorx	eax, r14d, 23
+        rol	r12d, 9
         xor	r14d, ebx
         vpslld	xmm6, xmm4, 23
         vpsrld	xmm5, xmm4, 9
         ; iter_5: 7 - 7
-        roll	r8d, 19
+        rol	r8d, 19
         xor	r14d, eax
         ; iter_6: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+48]
-        rorxl	ecx, r10d, 20
+        rorx	ecx, r10d, 20
         add	edx, r14d
         vpor	xmm8, xmm7, xmm8
         vpor	xmm6, xmm5, xmm6
@@ -9310,7 +9310,7 @@ L_SM3_AVX1_RORXlen_start:
         mov	eax, DWORD PTR [rsp+40]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+24]
-        roll	edx, 7
+        rol	edx, 7
         vpxor	xmm8, xmm6, xmm8
         vpxor	xmm4, xmm9, xmm4
         ; iter_6: 2 - 2
@@ -9332,21 +9332,21 @@ L_SM3_AVX1_RORXlen_start:
         ; iter_6: 5 - 5
         add	r9d, ecx
         add	r13d, edx
-        rorxl	ebx, r13d, 15
+        rorx	ebx, r13d, 15
         vpslld	xmm5, xmm4, 15
         vpsrld	xmm4, xmm4, 17
         ; iter_6: 6 - 6
-        rorxl	eax, r13d, 23
-        roll	r11d, 9
+        rorx	eax, r13d, 23
+        rol	r11d, 9
         xor	r13d, ebx
         vpor	xmm4, xmm5, xmm4
         ; iter_6: 7 - 7
-        roll	r15d, 19
+        rol	r15d, 19
         xor	r13d, eax
         vpxor	xmm10, xmm4, xmm10
         ; iter_7: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+56]
-        rorxl	ecx, r9d, 20
+        rorx	ecx, r9d, 20
         add	edx, r13d
         vpslld	xmm7, xmm10, 15
         vpsrld	xmm6, xmm10, 17
@@ -9354,7 +9354,7 @@ L_SM3_AVX1_RORXlen_start:
         mov	eax, DWORD PTR [rsp+44]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+28]
-        roll	edx, 7
+        rol	edx, 7
         vpslld	xmm5, xmm10, 23
         vpsrld	xmm4, xmm10, 9
         ; iter_7: 2 - 2
@@ -9380,14 +9380,14 @@ L_SM3_AVX1_RORXlen_start:
         ; iter_7: 5 - 5
         add	r8d, ecx
         add	r12d, edx
-        rorxl	ebx, r12d, 15
+        rorx	ebx, r12d, 15
         vpblendw	xmm1, xmm8, xmm10, 192
         ; iter_7: 6 - 6
-        rorxl	eax, r12d, 23
-        roll	r10d, 9
+        rorx	eax, r12d, 23
+        rol	r10d, 9
         xor	r12d, ebx
         ; iter_7: 7 - 7
-        roll	r14d, 19
+        rol	r14d, 19
         xor	r12d, eax
         ; msg_sched done: 4-7
         ; x2_to_w: 16
@@ -9396,14 +9396,14 @@ L_SM3_AVX1_RORXlen_start:
         ; msg_sched: 8-11
         ; iter_8: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+64]
-        rorxl	ecx, r8d, 20
+        rorx	ecx, r8d, 20
         add	edx, r12d
         vpalignr	xmm5, xmm3, xmm2, 12
         ; iter_8: 1 - 1
         mov	eax, DWORD PTR [rsp+48]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+32]
-        roll	edx, 7
+        rol	edx, 7
         vpalignr	xmm4, xmm1, xmm0, 8
         ; iter_8: 2 - 2
         xor	ecx, edx
@@ -9427,25 +9427,25 @@ L_SM3_AVX1_RORXlen_start:
         ; iter_8: 5 - 5
         add	r15d, ecx
         add	r11d, edx
-        rorxl	ebx, r11d, 15
+        rorx	ebx, r11d, 15
         vpalignr	xmm10, xmm0, xmm3, 12
         ; iter_8: 6 - 7
-        rorxl	eax, r11d, 23
-        roll	r9d, 9
+        rorx	eax, r11d, 23
+        rol	r9d, 9
         xor	r11d, ebx
-        roll	r13d, 19
+        rol	r13d, 19
         xor	r11d, eax
         vpxor	xmm10, xmm2, xmm10
         ; iter_9: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+72]
-        rorxl	ecx, r15d, 20
+        rorx	ecx, r15d, 20
         add	edx, r11d
         vpshufd	xmm4, xmm1, 249
         ; iter_9: 1 - 2
         mov	eax, DWORD PTR [rsp+52]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+36]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -9467,21 +9467,21 @@ L_SM3_AVX1_RORXlen_start:
         ; iter_9: 5 - 5
         add	r14d, ecx
         add	r10d, edx
-        rorxl	ebx, r10d, 15
+        rorx	ebx, r10d, 15
         vpslld	xmm8, xmm4, 15
         vpsrld	xmm7, xmm4, 17
         ; iter_9: 6 - 6
-        rorxl	eax, r10d, 23
-        roll	r8d, 9
+        rorx	eax, r10d, 23
+        rol	r8d, 9
         xor	r10d, ebx
         vpslld	xmm6, xmm4, 23
         vpsrld	xmm5, xmm4, 9
         ; iter_9: 7 - 7
-        roll	r12d, 19
+        rol	r12d, 19
         xor	r10d, eax
         ; iter_10: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+80]
-        rorxl	ecx, r14d, 20
+        rorx	ecx, r14d, 20
         add	edx, r10d
         vpor	xmm8, xmm7, xmm8
         vpor	xmm6, xmm5, xmm6
@@ -9489,7 +9489,7 @@ L_SM3_AVX1_RORXlen_start:
         mov	eax, DWORD PTR [rsp+56]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+40]
-        roll	edx, 7
+        rol	edx, 7
         vpxor	xmm8, xmm6, xmm8
         vpxor	xmm4, xmm9, xmm4
         ; iter_10: 2 - 2
@@ -9511,21 +9511,21 @@ L_SM3_AVX1_RORXlen_start:
         ; iter_10: 5 - 5
         add	r13d, ecx
         add	r9d, edx
-        rorxl	ebx, r9d, 15
+        rorx	ebx, r9d, 15
         vpslld	xmm5, xmm4, 15
         vpsrld	xmm4, xmm4, 17
         ; iter_10: 6 - 6
-        rorxl	eax, r9d, 23
-        roll	r15d, 9
+        rorx	eax, r9d, 23
+        rol	r15d, 9
         xor	r9d, ebx
         vpor	xmm4, xmm5, xmm4
         ; iter_10: 7 - 7
-        roll	r11d, 19
+        rol	r11d, 19
         xor	r9d, eax
         vpxor	xmm10, xmm4, xmm10
         ; iter_11: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+88]
-        rorxl	ecx, r13d, 20
+        rorx	ecx, r13d, 20
         add	edx, r9d
         vpslld	xmm7, xmm10, 15
         vpsrld	xmm6, xmm10, 17
@@ -9533,7 +9533,7 @@ L_SM3_AVX1_RORXlen_start:
         mov	eax, DWORD PTR [rsp+60]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+44]
-        roll	edx, 7
+        rol	edx, 7
         vpslld	xmm5, xmm10, 23
         vpsrld	xmm4, xmm10, 9
         ; iter_11: 2 - 2
@@ -9559,27 +9559,27 @@ L_SM3_AVX1_RORXlen_start:
         ; iter_11: 5 - 5
         add	r12d, ecx
         add	r8d, edx
-        rorxl	ebx, r8d, 15
+        rorx	ebx, r8d, 15
         vpblendw	xmm2, xmm8, xmm10, 192
         ; iter_11: 6 - 6
-        rorxl	eax, r8d, 23
-        roll	r14d, 9
+        rorx	eax, r8d, 23
+        rol	r14d, 9
         xor	r8d, ebx
         ; iter_11: 7 - 7
-        roll	r10d, 19
+        rol	r10d, 19
         xor	r8d, eax
         ; msg_sched done: 8-11
         ; msg_sched: 12-15
         ; iter_12: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+96]
-        rorxl	ecx, r12d, 20
+        rorx	ecx, r12d, 20
         add	edx, r8d
         vpalignr	xmm5, xmm0, xmm3, 12
         ; iter_12: 1 - 1
         mov	eax, DWORD PTR [rsp+64]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+48]
-        roll	edx, 7
+        rol	edx, 7
         vpalignr	xmm4, xmm2, xmm1, 8
         ; iter_12: 2 - 2
         xor	ecx, edx
@@ -9603,25 +9603,25 @@ L_SM3_AVX1_RORXlen_start:
         ; iter_12: 5 - 5
         add	r11d, ecx
         add	r15d, edx
-        rorxl	ebx, r15d, 15
+        rorx	ebx, r15d, 15
         vpalignr	xmm10, xmm1, xmm0, 12
         ; iter_12: 6 - 7
-        rorxl	eax, r15d, 23
-        roll	r13d, 9
+        rorx	eax, r15d, 23
+        rol	r13d, 9
         xor	r15d, ebx
-        roll	r9d, 19
+        rol	r9d, 19
         xor	r15d, eax
         vpxor	xmm10, xmm3, xmm10
         ; iter_13: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+104]
-        rorxl	ecx, r11d, 20
+        rorx	ecx, r11d, 20
         add	edx, r15d
         vpshufd	xmm4, xmm2, 249
         ; iter_13: 1 - 2
         mov	eax, DWORD PTR [rsp+68]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+52]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -9643,21 +9643,21 @@ L_SM3_AVX1_RORXlen_start:
         ; iter_13: 5 - 5
         add	r10d, ecx
         add	r14d, edx
-        rorxl	ebx, r14d, 15
+        rorx	ebx, r14d, 15
         vpslld	xmm8, xmm4, 15
         vpsrld	xmm7, xmm4, 17
         ; iter_13: 6 - 6
-        rorxl	eax, r14d, 23
-        roll	r12d, 9
+        rorx	eax, r14d, 23
+        rol	r12d, 9
         xor	r14d, ebx
         vpslld	xmm6, xmm4, 23
         vpsrld	xmm5, xmm4, 9
         ; iter_13: 7 - 7
-        roll	r8d, 19
+        rol	r8d, 19
         xor	r14d, eax
         ; iter_14: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+112]
-        rorxl	ecx, r10d, 20
+        rorx	ecx, r10d, 20
         add	edx, r14d
         vpor	xmm8, xmm7, xmm8
         vpor	xmm6, xmm5, xmm6
@@ -9665,7 +9665,7 @@ L_SM3_AVX1_RORXlen_start:
         mov	eax, DWORD PTR [rsp+72]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+56]
-        roll	edx, 7
+        rol	edx, 7
         vpxor	xmm8, xmm6, xmm8
         vpxor	xmm4, xmm9, xmm4
         ; iter_14: 2 - 2
@@ -9687,21 +9687,21 @@ L_SM3_AVX1_RORXlen_start:
         ; iter_14: 5 - 5
         add	r9d, ecx
         add	r13d, edx
-        rorxl	ebx, r13d, 15
+        rorx	ebx, r13d, 15
         vpslld	xmm5, xmm4, 15
         vpsrld	xmm4, xmm4, 17
         ; iter_14: 6 - 6
-        rorxl	eax, r13d, 23
-        roll	r11d, 9
+        rorx	eax, r13d, 23
+        rol	r11d, 9
         xor	r13d, ebx
         vpor	xmm4, xmm5, xmm4
         ; iter_14: 7 - 7
-        roll	r15d, 19
+        rol	r15d, 19
         xor	r13d, eax
         vpxor	xmm10, xmm4, xmm10
         ; iter_15: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+120]
-        rorxl	ecx, r9d, 20
+        rorx	ecx, r9d, 20
         add	edx, r13d
         vpslld	xmm7, xmm10, 15
         vpsrld	xmm6, xmm10, 17
@@ -9709,7 +9709,7 @@ L_SM3_AVX1_RORXlen_start:
         mov	eax, DWORD PTR [rsp+76]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+60]
-        roll	edx, 7
+        rol	edx, 7
         vpslld	xmm5, xmm10, 23
         vpsrld	xmm4, xmm10, 9
         ; iter_15: 2 - 2
@@ -9735,14 +9735,14 @@ L_SM3_AVX1_RORXlen_start:
         ; iter_15: 5 - 5
         add	r8d, ecx
         add	r12d, edx
-        rorxl	ebx, r12d, 15
+        rorx	ebx, r12d, 15
         vpblendw	xmm3, xmm8, xmm10, 192
         ; iter_15: 6 - 6
-        rorxl	eax, r12d, 23
-        roll	r10d, 9
+        rorx	eax, r12d, 23
+        rol	r10d, 9
         xor	r12d, ebx
         ; iter_15: 7 - 7
-        roll	r14d, 19
+        rol	r14d, 19
         xor	r12d, eax
         ; msg_sched done: 12-15
         ; x2_to_w: 24
@@ -9751,14 +9751,14 @@ L_SM3_AVX1_RORXlen_start:
         ; msg_sched: 16-19
         ; iter_16: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+128]
-        rorxl	ecx, r8d, 20
+        rorx	ecx, r8d, 20
         add	edx, r12d
         mov	eax, DWORD PTR [rsp+80]
         vpalignr	xmm5, xmm1, xmm0, 12
         ; iter_16: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+64]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpalignr	xmm4, xmm3, xmm2, 8
         ; iter_16: 2 - 2
@@ -9788,23 +9788,23 @@ L_SM3_AVX1_RORXlen_start:
         vpalignr	xmm10, xmm2, xmm1, 12
         ; iter_16: 6 - 7
         add	r11d, edx
-        rorxl	ebx, r11d, 15
-        rorxl	eax, r11d, 23
-        roll	r9d, 9
+        rorx	ebx, r11d, 15
+        rorx	eax, r11d, 23
+        rol	r9d, 9
         xor	r11d, ebx
-        roll	r13d, 19
+        rol	r13d, 19
         xor	r11d, eax
         vpxor	xmm10, xmm0, xmm10
         ; iter_17: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+136]
-        rorxl	ecx, r15d, 20
+        rorx	ecx, r15d, 20
         add	edx, r11d
         mov	eax, DWORD PTR [rsp+84]
         vpshufd	xmm4, xmm3, 249
         ; iter_17: 1 - 2
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+68]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -9833,18 +9833,18 @@ L_SM3_AVX1_RORXlen_start:
         vpsrld	xmm7, xmm4, 17
         ; iter_17: 6 - 6
         add	r10d, edx
-        rorxl	ebx, r10d, 15
-        rorxl	eax, r10d, 23
-        roll	r8d, 9
+        rorx	ebx, r10d, 15
+        rorx	eax, r10d, 23
+        rol	r8d, 9
         vpslld	xmm6, xmm4, 23
         vpsrld	xmm5, xmm4, 9
         ; iter_17: 7 - 7
         xor	r10d, ebx
-        roll	r12d, 19
+        rol	r12d, 19
         xor	r10d, eax
         ; iter_18: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+144]
-        rorxl	ecx, r14d, 20
+        rorx	ecx, r14d, 20
         add	edx, r10d
         mov	eax, DWORD PTR [rsp+88]
         vpor	xmm8, xmm7, xmm8
@@ -9852,7 +9852,7 @@ L_SM3_AVX1_RORXlen_start:
         ; iter_18: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+72]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpxor	xmm8, xmm6, xmm8
         vpxor	xmm4, xmm9, xmm4
@@ -9881,18 +9881,18 @@ L_SM3_AVX1_RORXlen_start:
         vpsrld	xmm4, xmm4, 17
         ; iter_18: 6 - 6
         add	r9d, edx
-        rorxl	ebx, r9d, 15
-        rorxl	eax, r9d, 23
-        roll	r15d, 9
+        rorx	ebx, r9d, 15
+        rorx	eax, r9d, 23
+        rol	r15d, 9
         vpor	xmm4, xmm5, xmm4
         ; iter_18: 7 - 7
         xor	r9d, ebx
-        roll	r11d, 19
+        rol	r11d, 19
         xor	r9d, eax
         vpxor	xmm10, xmm4, xmm10
         ; iter_19: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+152]
-        rorxl	ecx, r13d, 20
+        rorx	ecx, r13d, 20
         add	edx, r9d
         mov	eax, DWORD PTR [rsp+92]
         vpslld	xmm7, xmm10, 15
@@ -9900,7 +9900,7 @@ L_SM3_AVX1_RORXlen_start:
         ; iter_19: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+76]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpslld	xmm5, xmm10, 23
         vpsrld	xmm4, xmm10, 9
@@ -9932,25 +9932,25 @@ L_SM3_AVX1_RORXlen_start:
         vpblendw	xmm0, xmm8, xmm10, 192
         ; iter_19: 6 - 6
         add	r8d, edx
-        rorxl	ebx, r8d, 15
-        rorxl	eax, r8d, 23
-        roll	r14d, 9
+        rorx	ebx, r8d, 15
+        rorx	eax, r8d, 23
+        rol	r14d, 9
         ; iter_19: 7 - 7
         xor	r8d, ebx
-        roll	r10d, 19
+        rol	r10d, 19
         xor	r8d, eax
         ; msg_sched done: 16-19
         ; msg_sched: 20-23
         ; iter_20: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+160]
-        rorxl	ecx, r12d, 20
+        rorx	ecx, r12d, 20
         add	edx, r8d
         mov	eax, DWORD PTR [rsp+96]
         vpalignr	xmm5, xmm2, xmm1, 12
         ; iter_20: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+80]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpalignr	xmm4, xmm0, xmm3, 8
         ; iter_20: 2 - 2
@@ -9980,23 +9980,23 @@ L_SM3_AVX1_RORXlen_start:
         vpalignr	xmm10, xmm3, xmm2, 12
         ; iter_20: 6 - 7
         add	r15d, edx
-        rorxl	ebx, r15d, 15
-        rorxl	eax, r15d, 23
-        roll	r13d, 9
+        rorx	ebx, r15d, 15
+        rorx	eax, r15d, 23
+        rol	r13d, 9
         xor	r15d, ebx
-        roll	r9d, 19
+        rol	r9d, 19
         xor	r15d, eax
         vpxor	xmm10, xmm1, xmm10
         ; iter_21: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+168]
-        rorxl	ecx, r11d, 20
+        rorx	ecx, r11d, 20
         add	edx, r15d
         mov	eax, DWORD PTR [rsp+100]
         vpshufd	xmm4, xmm0, 249
         ; iter_21: 1 - 2
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+84]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -10025,18 +10025,18 @@ L_SM3_AVX1_RORXlen_start:
         vpsrld	xmm7, xmm4, 17
         ; iter_21: 6 - 6
         add	r14d, edx
-        rorxl	ebx, r14d, 15
-        rorxl	eax, r14d, 23
-        roll	r12d, 9
+        rorx	ebx, r14d, 15
+        rorx	eax, r14d, 23
+        rol	r12d, 9
         vpslld	xmm6, xmm4, 23
         vpsrld	xmm5, xmm4, 9
         ; iter_21: 7 - 7
         xor	r14d, ebx
-        roll	r8d, 19
+        rol	r8d, 19
         xor	r14d, eax
         ; iter_22: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+176]
-        rorxl	ecx, r10d, 20
+        rorx	ecx, r10d, 20
         add	edx, r14d
         mov	eax, DWORD PTR [rsp+104]
         vpor	xmm8, xmm7, xmm8
@@ -10044,7 +10044,7 @@ L_SM3_AVX1_RORXlen_start:
         ; iter_22: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+88]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpxor	xmm8, xmm6, xmm8
         vpxor	xmm4, xmm9, xmm4
@@ -10073,18 +10073,18 @@ L_SM3_AVX1_RORXlen_start:
         vpsrld	xmm4, xmm4, 17
         ; iter_22: 6 - 6
         add	r13d, edx
-        rorxl	ebx, r13d, 15
-        rorxl	eax, r13d, 23
-        roll	r11d, 9
+        rorx	ebx, r13d, 15
+        rorx	eax, r13d, 23
+        rol	r11d, 9
         vpor	xmm4, xmm5, xmm4
         ; iter_22: 7 - 7
         xor	r13d, ebx
-        roll	r15d, 19
+        rol	r15d, 19
         xor	r13d, eax
         vpxor	xmm10, xmm4, xmm10
         ; iter_23: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+184]
-        rorxl	ecx, r9d, 20
+        rorx	ecx, r9d, 20
         add	edx, r13d
         mov	eax, DWORD PTR [rsp+108]
         vpslld	xmm7, xmm10, 15
@@ -10092,7 +10092,7 @@ L_SM3_AVX1_RORXlen_start:
         ; iter_23: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+92]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpslld	xmm5, xmm10, 23
         vpsrld	xmm4, xmm10, 9
@@ -10124,12 +10124,12 @@ L_SM3_AVX1_RORXlen_start:
         vpblendw	xmm1, xmm8, xmm10, 192
         ; iter_23: 6 - 6
         add	r12d, edx
-        rorxl	ebx, r12d, 15
-        rorxl	eax, r12d, 23
-        roll	r10d, 9
+        rorx	ebx, r12d, 15
+        rorx	eax, r12d, 23
+        rol	r10d, 9
         ; iter_23: 7 - 7
         xor	r12d, ebx
-        roll	r14d, 19
+        rol	r14d, 19
         xor	r12d, eax
         ; msg_sched done: 20-23
         ; x2_to_w: 32
@@ -10138,14 +10138,14 @@ L_SM3_AVX1_RORXlen_start:
         ; msg_sched: 24-27
         ; iter_24: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+192]
-        rorxl	ecx, r8d, 20
+        rorx	ecx, r8d, 20
         add	edx, r12d
         mov	eax, DWORD PTR [rsp+112]
         vpalignr	xmm5, xmm3, xmm2, 12
         ; iter_24: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+96]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpalignr	xmm4, xmm1, xmm0, 8
         ; iter_24: 2 - 2
@@ -10175,23 +10175,23 @@ L_SM3_AVX1_RORXlen_start:
         vpalignr	xmm10, xmm0, xmm3, 12
         ; iter_24: 6 - 7
         add	r11d, edx
-        rorxl	ebx, r11d, 15
-        rorxl	eax, r11d, 23
-        roll	r9d, 9
+        rorx	ebx, r11d, 15
+        rorx	eax, r11d, 23
+        rol	r9d, 9
         xor	r11d, ebx
-        roll	r13d, 19
+        rol	r13d, 19
         xor	r11d, eax
         vpxor	xmm10, xmm2, xmm10
         ; iter_25: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+200]
-        rorxl	ecx, r15d, 20
+        rorx	ecx, r15d, 20
         add	edx, r11d
         mov	eax, DWORD PTR [rsp+116]
         vpshufd	xmm4, xmm1, 249
         ; iter_25: 1 - 2
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+100]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -10220,18 +10220,18 @@ L_SM3_AVX1_RORXlen_start:
         vpsrld	xmm7, xmm4, 17
         ; iter_25: 6 - 6
         add	r10d, edx
-        rorxl	ebx, r10d, 15
-        rorxl	eax, r10d, 23
-        roll	r8d, 9
+        rorx	ebx, r10d, 15
+        rorx	eax, r10d, 23
+        rol	r8d, 9
         vpslld	xmm6, xmm4, 23
         vpsrld	xmm5, xmm4, 9
         ; iter_25: 7 - 7
         xor	r10d, ebx
-        roll	r12d, 19
+        rol	r12d, 19
         xor	r10d, eax
         ; iter_26: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+208]
-        rorxl	ecx, r14d, 20
+        rorx	ecx, r14d, 20
         add	edx, r10d
         mov	eax, DWORD PTR [rsp+120]
         vpor	xmm8, xmm7, xmm8
@@ -10239,7 +10239,7 @@ L_SM3_AVX1_RORXlen_start:
         ; iter_26: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+104]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpxor	xmm8, xmm6, xmm8
         vpxor	xmm4, xmm9, xmm4
@@ -10268,18 +10268,18 @@ L_SM3_AVX1_RORXlen_start:
         vpsrld	xmm4, xmm4, 17
         ; iter_26: 6 - 6
         add	r9d, edx
-        rorxl	ebx, r9d, 15
-        rorxl	eax, r9d, 23
-        roll	r15d, 9
+        rorx	ebx, r9d, 15
+        rorx	eax, r9d, 23
+        rol	r15d, 9
         vpor	xmm4, xmm5, xmm4
         ; iter_26: 7 - 7
         xor	r9d, ebx
-        roll	r11d, 19
+        rol	r11d, 19
         xor	r9d, eax
         vpxor	xmm10, xmm4, xmm10
         ; iter_27: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+216]
-        rorxl	ecx, r13d, 20
+        rorx	ecx, r13d, 20
         add	edx, r9d
         mov	eax, DWORD PTR [rsp+124]
         vpslld	xmm7, xmm10, 15
@@ -10287,7 +10287,7 @@ L_SM3_AVX1_RORXlen_start:
         ; iter_27: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+108]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpslld	xmm5, xmm10, 23
         vpsrld	xmm4, xmm10, 9
@@ -10319,25 +10319,25 @@ L_SM3_AVX1_RORXlen_start:
         vpblendw	xmm2, xmm8, xmm10, 192
         ; iter_27: 6 - 6
         add	r8d, edx
-        rorxl	ebx, r8d, 15
-        rorxl	eax, r8d, 23
-        roll	r14d, 9
+        rorx	ebx, r8d, 15
+        rorx	eax, r8d, 23
+        rol	r14d, 9
         ; iter_27: 7 - 7
         xor	r8d, ebx
-        roll	r10d, 19
+        rol	r10d, 19
         xor	r8d, eax
         ; msg_sched done: 24-27
         ; msg_sched: 28-31
         ; iter_28: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+224]
-        rorxl	ecx, r12d, 20
+        rorx	ecx, r12d, 20
         add	edx, r8d
         mov	eax, DWORD PTR [rsp+128]
         vpalignr	xmm5, xmm0, xmm3, 12
         ; iter_28: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+112]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpalignr	xmm4, xmm2, xmm1, 8
         ; iter_28: 2 - 2
@@ -10367,23 +10367,23 @@ L_SM3_AVX1_RORXlen_start:
         vpalignr	xmm10, xmm1, xmm0, 12
         ; iter_28: 6 - 7
         add	r15d, edx
-        rorxl	ebx, r15d, 15
-        rorxl	eax, r15d, 23
-        roll	r13d, 9
+        rorx	ebx, r15d, 15
+        rorx	eax, r15d, 23
+        rol	r13d, 9
         xor	r15d, ebx
-        roll	r9d, 19
+        rol	r9d, 19
         xor	r15d, eax
         vpxor	xmm10, xmm3, xmm10
         ; iter_29: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+232]
-        rorxl	ecx, r11d, 20
+        rorx	ecx, r11d, 20
         add	edx, r15d
         mov	eax, DWORD PTR [rsp+132]
         vpshufd	xmm4, xmm2, 249
         ; iter_29: 1 - 2
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+116]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -10412,18 +10412,18 @@ L_SM3_AVX1_RORXlen_start:
         vpsrld	xmm7, xmm4, 17
         ; iter_29: 6 - 6
         add	r14d, edx
-        rorxl	ebx, r14d, 15
-        rorxl	eax, r14d, 23
-        roll	r12d, 9
+        rorx	ebx, r14d, 15
+        rorx	eax, r14d, 23
+        rol	r12d, 9
         vpslld	xmm6, xmm4, 23
         vpsrld	xmm5, xmm4, 9
         ; iter_29: 7 - 7
         xor	r14d, ebx
-        roll	r8d, 19
+        rol	r8d, 19
         xor	r14d, eax
         ; iter_30: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+240]
-        rorxl	ecx, r10d, 20
+        rorx	ecx, r10d, 20
         add	edx, r14d
         mov	eax, DWORD PTR [rsp+136]
         vpor	xmm8, xmm7, xmm8
@@ -10431,7 +10431,7 @@ L_SM3_AVX1_RORXlen_start:
         ; iter_30: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+120]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpxor	xmm8, xmm6, xmm8
         vpxor	xmm4, xmm9, xmm4
@@ -10460,18 +10460,18 @@ L_SM3_AVX1_RORXlen_start:
         vpsrld	xmm4, xmm4, 17
         ; iter_30: 6 - 6
         add	r13d, edx
-        rorxl	ebx, r13d, 15
-        rorxl	eax, r13d, 23
-        roll	r11d, 9
+        rorx	ebx, r13d, 15
+        rorx	eax, r13d, 23
+        rol	r11d, 9
         vpor	xmm4, xmm5, xmm4
         ; iter_30: 7 - 7
         xor	r13d, ebx
-        roll	r15d, 19
+        rol	r15d, 19
         xor	r13d, eax
         vpxor	xmm10, xmm4, xmm10
         ; iter_31: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+248]
-        rorxl	ecx, r9d, 20
+        rorx	ecx, r9d, 20
         add	edx, r13d
         mov	eax, DWORD PTR [rsp+140]
         vpslld	xmm7, xmm10, 15
@@ -10479,7 +10479,7 @@ L_SM3_AVX1_RORXlen_start:
         ; iter_31: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+124]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpslld	xmm5, xmm10, 23
         vpsrld	xmm4, xmm10, 9
@@ -10511,12 +10511,12 @@ L_SM3_AVX1_RORXlen_start:
         vpblendw	xmm3, xmm8, xmm10, 192
         ; iter_31: 6 - 6
         add	r12d, edx
-        rorxl	ebx, r12d, 15
-        rorxl	eax, r12d, 23
-        roll	r10d, 9
+        rorx	ebx, r12d, 15
+        rorx	eax, r12d, 23
+        rol	r10d, 9
         ; iter_31: 7 - 7
         xor	r12d, ebx
-        roll	r14d, 19
+        rol	r14d, 19
         xor	r12d, eax
         ; msg_sched done: 28-31
         ; x2_to_w: 40
@@ -10525,14 +10525,14 @@ L_SM3_AVX1_RORXlen_start:
         ; msg_sched: 32-35
         ; iter_32: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+256]
-        rorxl	ecx, r8d, 20
+        rorx	ecx, r8d, 20
         add	edx, r12d
         mov	eax, DWORD PTR [rsp+144]
         vpalignr	xmm5, xmm1, xmm0, 12
         ; iter_32: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+128]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpalignr	xmm4, xmm3, xmm2, 8
         ; iter_32: 2 - 2
@@ -10562,23 +10562,23 @@ L_SM3_AVX1_RORXlen_start:
         vpalignr	xmm10, xmm2, xmm1, 12
         ; iter_32: 6 - 7
         add	r11d, edx
-        rorxl	ebx, r11d, 15
-        rorxl	eax, r11d, 23
-        roll	r9d, 9
+        rorx	ebx, r11d, 15
+        rorx	eax, r11d, 23
+        rol	r9d, 9
         xor	r11d, ebx
-        roll	r13d, 19
+        rol	r13d, 19
         xor	r11d, eax
         vpxor	xmm10, xmm0, xmm10
         ; iter_33: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+264]
-        rorxl	ecx, r15d, 20
+        rorx	ecx, r15d, 20
         add	edx, r11d
         mov	eax, DWORD PTR [rsp+148]
         vpshufd	xmm4, xmm3, 249
         ; iter_33: 1 - 2
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+132]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -10607,18 +10607,18 @@ L_SM3_AVX1_RORXlen_start:
         vpsrld	xmm7, xmm4, 17
         ; iter_33: 6 - 6
         add	r10d, edx
-        rorxl	ebx, r10d, 15
-        rorxl	eax, r10d, 23
-        roll	r8d, 9
+        rorx	ebx, r10d, 15
+        rorx	eax, r10d, 23
+        rol	r8d, 9
         vpslld	xmm6, xmm4, 23
         vpsrld	xmm5, xmm4, 9
         ; iter_33: 7 - 7
         xor	r10d, ebx
-        roll	r12d, 19
+        rol	r12d, 19
         xor	r10d, eax
         ; iter_34: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+272]
-        rorxl	ecx, r14d, 20
+        rorx	ecx, r14d, 20
         add	edx, r10d
         mov	eax, DWORD PTR [rsp+152]
         vpor	xmm8, xmm7, xmm8
@@ -10626,7 +10626,7 @@ L_SM3_AVX1_RORXlen_start:
         ; iter_34: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+136]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpxor	xmm8, xmm6, xmm8
         vpxor	xmm4, xmm9, xmm4
@@ -10655,18 +10655,18 @@ L_SM3_AVX1_RORXlen_start:
         vpsrld	xmm4, xmm4, 17
         ; iter_34: 6 - 6
         add	r9d, edx
-        rorxl	ebx, r9d, 15
-        rorxl	eax, r9d, 23
-        roll	r15d, 9
+        rorx	ebx, r9d, 15
+        rorx	eax, r9d, 23
+        rol	r15d, 9
         vpor	xmm4, xmm5, xmm4
         ; iter_34: 7 - 7
         xor	r9d, ebx
-        roll	r11d, 19
+        rol	r11d, 19
         xor	r9d, eax
         vpxor	xmm10, xmm4, xmm10
         ; iter_35: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+280]
-        rorxl	ecx, r13d, 20
+        rorx	ecx, r13d, 20
         add	edx, r9d
         mov	eax, DWORD PTR [rsp+156]
         vpslld	xmm7, xmm10, 15
@@ -10674,7 +10674,7 @@ L_SM3_AVX1_RORXlen_start:
         ; iter_35: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+140]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpslld	xmm5, xmm10, 23
         vpsrld	xmm4, xmm10, 9
@@ -10706,25 +10706,25 @@ L_SM3_AVX1_RORXlen_start:
         vpblendw	xmm0, xmm8, xmm10, 192
         ; iter_35: 6 - 6
         add	r8d, edx
-        rorxl	ebx, r8d, 15
-        rorxl	eax, r8d, 23
-        roll	r14d, 9
+        rorx	ebx, r8d, 15
+        rorx	eax, r8d, 23
+        rol	r14d, 9
         ; iter_35: 7 - 7
         xor	r8d, ebx
-        roll	r10d, 19
+        rol	r10d, 19
         xor	r8d, eax
         ; msg_sched done: 32-35
         ; msg_sched: 36-39
         ; iter_36: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+288]
-        rorxl	ecx, r12d, 20
+        rorx	ecx, r12d, 20
         add	edx, r8d
         mov	eax, DWORD PTR [rsp+160]
         vpalignr	xmm5, xmm2, xmm1, 12
         ; iter_36: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+144]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpalignr	xmm4, xmm0, xmm3, 8
         ; iter_36: 2 - 2
@@ -10754,23 +10754,23 @@ L_SM3_AVX1_RORXlen_start:
         vpalignr	xmm10, xmm3, xmm2, 12
         ; iter_36: 6 - 7
         add	r15d, edx
-        rorxl	ebx, r15d, 15
-        rorxl	eax, r15d, 23
-        roll	r13d, 9
+        rorx	ebx, r15d, 15
+        rorx	eax, r15d, 23
+        rol	r13d, 9
         xor	r15d, ebx
-        roll	r9d, 19
+        rol	r9d, 19
         xor	r15d, eax
         vpxor	xmm10, xmm1, xmm10
         ; iter_37: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+296]
-        rorxl	ecx, r11d, 20
+        rorx	ecx, r11d, 20
         add	edx, r15d
         mov	eax, DWORD PTR [rsp+164]
         vpshufd	xmm4, xmm0, 249
         ; iter_37: 1 - 2
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+148]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -10799,18 +10799,18 @@ L_SM3_AVX1_RORXlen_start:
         vpsrld	xmm7, xmm4, 17
         ; iter_37: 6 - 6
         add	r14d, edx
-        rorxl	ebx, r14d, 15
-        rorxl	eax, r14d, 23
-        roll	r12d, 9
+        rorx	ebx, r14d, 15
+        rorx	eax, r14d, 23
+        rol	r12d, 9
         vpslld	xmm6, xmm4, 23
         vpsrld	xmm5, xmm4, 9
         ; iter_37: 7 - 7
         xor	r14d, ebx
-        roll	r8d, 19
+        rol	r8d, 19
         xor	r14d, eax
         ; iter_38: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+304]
-        rorxl	ecx, r10d, 20
+        rorx	ecx, r10d, 20
         add	edx, r14d
         mov	eax, DWORD PTR [rsp+168]
         vpor	xmm8, xmm7, xmm8
@@ -10818,7 +10818,7 @@ L_SM3_AVX1_RORXlen_start:
         ; iter_38: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+152]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpxor	xmm8, xmm6, xmm8
         vpxor	xmm4, xmm9, xmm4
@@ -10847,18 +10847,18 @@ L_SM3_AVX1_RORXlen_start:
         vpsrld	xmm4, xmm4, 17
         ; iter_38: 6 - 6
         add	r13d, edx
-        rorxl	ebx, r13d, 15
-        rorxl	eax, r13d, 23
-        roll	r11d, 9
+        rorx	ebx, r13d, 15
+        rorx	eax, r13d, 23
+        rol	r11d, 9
         vpor	xmm4, xmm5, xmm4
         ; iter_38: 7 - 7
         xor	r13d, ebx
-        roll	r15d, 19
+        rol	r15d, 19
         xor	r13d, eax
         vpxor	xmm10, xmm4, xmm10
         ; iter_39: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+312]
-        rorxl	ecx, r9d, 20
+        rorx	ecx, r9d, 20
         add	edx, r13d
         mov	eax, DWORD PTR [rsp+172]
         vpslld	xmm7, xmm10, 15
@@ -10866,7 +10866,7 @@ L_SM3_AVX1_RORXlen_start:
         ; iter_39: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+156]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpslld	xmm5, xmm10, 23
         vpsrld	xmm4, xmm10, 9
@@ -10898,12 +10898,12 @@ L_SM3_AVX1_RORXlen_start:
         vpblendw	xmm1, xmm8, xmm10, 192
         ; iter_39: 6 - 6
         add	r12d, edx
-        rorxl	ebx, r12d, 15
-        rorxl	eax, r12d, 23
-        roll	r10d, 9
+        rorx	ebx, r12d, 15
+        rorx	eax, r12d, 23
+        rol	r10d, 9
         ; iter_39: 7 - 7
         xor	r12d, ebx
-        roll	r14d, 19
+        rol	r14d, 19
         xor	r12d, eax
         ; msg_sched done: 36-39
         ; x2_to_w: 48
@@ -10912,14 +10912,14 @@ L_SM3_AVX1_RORXlen_start:
         ; msg_sched: 40-43
         ; iter_40: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+320]
-        rorxl	ecx, r8d, 20
+        rorx	ecx, r8d, 20
         add	edx, r12d
         mov	eax, DWORD PTR [rsp+176]
         vpalignr	xmm5, xmm3, xmm2, 12
         ; iter_40: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+160]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpalignr	xmm4, xmm1, xmm0, 8
         ; iter_40: 2 - 2
@@ -10949,23 +10949,23 @@ L_SM3_AVX1_RORXlen_start:
         vpalignr	xmm10, xmm0, xmm3, 12
         ; iter_40: 6 - 7
         add	r11d, edx
-        rorxl	ebx, r11d, 15
-        rorxl	eax, r11d, 23
-        roll	r9d, 9
+        rorx	ebx, r11d, 15
+        rorx	eax, r11d, 23
+        rol	r9d, 9
         xor	r11d, ebx
-        roll	r13d, 19
+        rol	r13d, 19
         xor	r11d, eax
         vpxor	xmm10, xmm2, xmm10
         ; iter_41: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+328]
-        rorxl	ecx, r15d, 20
+        rorx	ecx, r15d, 20
         add	edx, r11d
         mov	eax, DWORD PTR [rsp+180]
         vpshufd	xmm4, xmm1, 249
         ; iter_41: 1 - 2
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+164]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -10994,18 +10994,18 @@ L_SM3_AVX1_RORXlen_start:
         vpsrld	xmm7, xmm4, 17
         ; iter_41: 6 - 6
         add	r10d, edx
-        rorxl	ebx, r10d, 15
-        rorxl	eax, r10d, 23
-        roll	r8d, 9
+        rorx	ebx, r10d, 15
+        rorx	eax, r10d, 23
+        rol	r8d, 9
         vpslld	xmm6, xmm4, 23
         vpsrld	xmm5, xmm4, 9
         ; iter_41: 7 - 7
         xor	r10d, ebx
-        roll	r12d, 19
+        rol	r12d, 19
         xor	r10d, eax
         ; iter_42: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+336]
-        rorxl	ecx, r14d, 20
+        rorx	ecx, r14d, 20
         add	edx, r10d
         mov	eax, DWORD PTR [rsp+184]
         vpor	xmm8, xmm7, xmm8
@@ -11013,7 +11013,7 @@ L_SM3_AVX1_RORXlen_start:
         ; iter_42: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+168]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpxor	xmm8, xmm6, xmm8
         vpxor	xmm4, xmm9, xmm4
@@ -11042,18 +11042,18 @@ L_SM3_AVX1_RORXlen_start:
         vpsrld	xmm4, xmm4, 17
         ; iter_42: 6 - 6
         add	r9d, edx
-        rorxl	ebx, r9d, 15
-        rorxl	eax, r9d, 23
-        roll	r15d, 9
+        rorx	ebx, r9d, 15
+        rorx	eax, r9d, 23
+        rol	r15d, 9
         vpor	xmm4, xmm5, xmm4
         ; iter_42: 7 - 7
         xor	r9d, ebx
-        roll	r11d, 19
+        rol	r11d, 19
         xor	r9d, eax
         vpxor	xmm10, xmm4, xmm10
         ; iter_43: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+344]
-        rorxl	ecx, r13d, 20
+        rorx	ecx, r13d, 20
         add	edx, r9d
         mov	eax, DWORD PTR [rsp+188]
         vpslld	xmm7, xmm10, 15
@@ -11061,7 +11061,7 @@ L_SM3_AVX1_RORXlen_start:
         ; iter_43: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+172]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpslld	xmm5, xmm10, 23
         vpsrld	xmm4, xmm10, 9
@@ -11093,25 +11093,25 @@ L_SM3_AVX1_RORXlen_start:
         vpblendw	xmm2, xmm8, xmm10, 192
         ; iter_43: 6 - 6
         add	r8d, edx
-        rorxl	ebx, r8d, 15
-        rorxl	eax, r8d, 23
-        roll	r14d, 9
+        rorx	ebx, r8d, 15
+        rorx	eax, r8d, 23
+        rol	r14d, 9
         ; iter_43: 7 - 7
         xor	r8d, ebx
-        roll	r10d, 19
+        rol	r10d, 19
         xor	r8d, eax
         ; msg_sched done: 40-43
         ; msg_sched: 44-47
         ; iter_44: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+352]
-        rorxl	ecx, r12d, 20
+        rorx	ecx, r12d, 20
         add	edx, r8d
         mov	eax, DWORD PTR [rsp+192]
         vpalignr	xmm5, xmm0, xmm3, 12
         ; iter_44: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+176]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpalignr	xmm4, xmm2, xmm1, 8
         ; iter_44: 2 - 2
@@ -11141,23 +11141,23 @@ L_SM3_AVX1_RORXlen_start:
         vpalignr	xmm10, xmm1, xmm0, 12
         ; iter_44: 6 - 7
         add	r15d, edx
-        rorxl	ebx, r15d, 15
-        rorxl	eax, r15d, 23
-        roll	r13d, 9
+        rorx	ebx, r15d, 15
+        rorx	eax, r15d, 23
+        rol	r13d, 9
         xor	r15d, ebx
-        roll	r9d, 19
+        rol	r9d, 19
         xor	r15d, eax
         vpxor	xmm10, xmm3, xmm10
         ; iter_45: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+360]
-        rorxl	ecx, r11d, 20
+        rorx	ecx, r11d, 20
         add	edx, r15d
         mov	eax, DWORD PTR [rsp+196]
         vpshufd	xmm4, xmm2, 249
         ; iter_45: 1 - 2
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+180]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -11186,18 +11186,18 @@ L_SM3_AVX1_RORXlen_start:
         vpsrld	xmm7, xmm4, 17
         ; iter_45: 6 - 6
         add	r14d, edx
-        rorxl	ebx, r14d, 15
-        rorxl	eax, r14d, 23
-        roll	r12d, 9
+        rorx	ebx, r14d, 15
+        rorx	eax, r14d, 23
+        rol	r12d, 9
         vpslld	xmm6, xmm4, 23
         vpsrld	xmm5, xmm4, 9
         ; iter_45: 7 - 7
         xor	r14d, ebx
-        roll	r8d, 19
+        rol	r8d, 19
         xor	r14d, eax
         ; iter_46: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+368]
-        rorxl	ecx, r10d, 20
+        rorx	ecx, r10d, 20
         add	edx, r14d
         mov	eax, DWORD PTR [rsp+200]
         vpor	xmm8, xmm7, xmm8
@@ -11205,7 +11205,7 @@ L_SM3_AVX1_RORXlen_start:
         ; iter_46: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+184]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpxor	xmm8, xmm6, xmm8
         vpxor	xmm4, xmm9, xmm4
@@ -11234,18 +11234,18 @@ L_SM3_AVX1_RORXlen_start:
         vpsrld	xmm4, xmm4, 17
         ; iter_46: 6 - 6
         add	r13d, edx
-        rorxl	ebx, r13d, 15
-        rorxl	eax, r13d, 23
-        roll	r11d, 9
+        rorx	ebx, r13d, 15
+        rorx	eax, r13d, 23
+        rol	r11d, 9
         vpor	xmm4, xmm5, xmm4
         ; iter_46: 7 - 7
         xor	r13d, ebx
-        roll	r15d, 19
+        rol	r15d, 19
         xor	r13d, eax
         vpxor	xmm10, xmm4, xmm10
         ; iter_47: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+376]
-        rorxl	ecx, r9d, 20
+        rorx	ecx, r9d, 20
         add	edx, r13d
         mov	eax, DWORD PTR [rsp+204]
         vpslld	xmm7, xmm10, 15
@@ -11253,7 +11253,7 @@ L_SM3_AVX1_RORXlen_start:
         ; iter_47: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+188]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpslld	xmm5, xmm10, 23
         vpsrld	xmm4, xmm10, 9
@@ -11285,12 +11285,12 @@ L_SM3_AVX1_RORXlen_start:
         vpblendw	xmm3, xmm8, xmm10, 192
         ; iter_47: 6 - 6
         add	r12d, edx
-        rorxl	ebx, r12d, 15
-        rorxl	eax, r12d, 23
-        roll	r10d, 9
+        rorx	ebx, r12d, 15
+        rorx	eax, r12d, 23
+        rol	r10d, 9
         ; iter_47: 7 - 7
         xor	r12d, ebx
-        roll	r14d, 19
+        rol	r14d, 19
         xor	r12d, eax
         ; msg_sched done: 44-47
         ; x2_to_w: 56
@@ -11299,14 +11299,14 @@ L_SM3_AVX1_RORXlen_start:
         ; msg_sched: 48-51
         ; iter_48: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+384]
-        rorxl	ecx, r8d, 20
+        rorx	ecx, r8d, 20
         add	edx, r12d
         mov	eax, DWORD PTR [rsp+208]
         vpalignr	xmm5, xmm1, xmm0, 12
         ; iter_48: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+192]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpalignr	xmm4, xmm3, xmm2, 8
         ; iter_48: 2 - 2
@@ -11336,23 +11336,23 @@ L_SM3_AVX1_RORXlen_start:
         vpalignr	xmm10, xmm2, xmm1, 12
         ; iter_48: 6 - 7
         add	r11d, edx
-        rorxl	ebx, r11d, 15
-        rorxl	eax, r11d, 23
-        roll	r9d, 9
+        rorx	ebx, r11d, 15
+        rorx	eax, r11d, 23
+        rol	r9d, 9
         xor	r11d, ebx
-        roll	r13d, 19
+        rol	r13d, 19
         xor	r11d, eax
         vpxor	xmm10, xmm0, xmm10
         ; iter_49: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+392]
-        rorxl	ecx, r15d, 20
+        rorx	ecx, r15d, 20
         add	edx, r11d
         mov	eax, DWORD PTR [rsp+212]
         vpshufd	xmm4, xmm3, 249
         ; iter_49: 1 - 2
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+196]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -11381,18 +11381,18 @@ L_SM3_AVX1_RORXlen_start:
         vpsrld	xmm7, xmm4, 17
         ; iter_49: 6 - 6
         add	r10d, edx
-        rorxl	ebx, r10d, 15
-        rorxl	eax, r10d, 23
-        roll	r8d, 9
+        rorx	ebx, r10d, 15
+        rorx	eax, r10d, 23
+        rol	r8d, 9
         vpslld	xmm6, xmm4, 23
         vpsrld	xmm5, xmm4, 9
         ; iter_49: 7 - 7
         xor	r10d, ebx
-        roll	r12d, 19
+        rol	r12d, 19
         xor	r10d, eax
         ; iter_50: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+400]
-        rorxl	ecx, r14d, 20
+        rorx	ecx, r14d, 20
         add	edx, r10d
         mov	eax, DWORD PTR [rsp+216]
         vpor	xmm8, xmm7, xmm8
@@ -11400,7 +11400,7 @@ L_SM3_AVX1_RORXlen_start:
         ; iter_50: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+200]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpxor	xmm8, xmm6, xmm8
         vpxor	xmm4, xmm9, xmm4
@@ -11429,18 +11429,18 @@ L_SM3_AVX1_RORXlen_start:
         vpsrld	xmm4, xmm4, 17
         ; iter_50: 6 - 6
         add	r9d, edx
-        rorxl	ebx, r9d, 15
-        rorxl	eax, r9d, 23
-        roll	r15d, 9
+        rorx	ebx, r9d, 15
+        rorx	eax, r9d, 23
+        rol	r15d, 9
         vpor	xmm4, xmm5, xmm4
         ; iter_50: 7 - 7
         xor	r9d, ebx
-        roll	r11d, 19
+        rol	r11d, 19
         xor	r9d, eax
         vpxor	xmm10, xmm4, xmm10
         ; iter_51: 0 - 0
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+408]
-        rorxl	ecx, r13d, 20
+        rorx	ecx, r13d, 20
         add	edx, r9d
         mov	eax, DWORD PTR [rsp+220]
         vpslld	xmm7, xmm10, 15
@@ -11448,7 +11448,7 @@ L_SM3_AVX1_RORXlen_start:
         ; iter_51: 1 - 1
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+204]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         vpslld	xmm5, xmm10, 23
         vpsrld	xmm4, xmm10, 9
@@ -11480,22 +11480,22 @@ L_SM3_AVX1_RORXlen_start:
         vpblendw	xmm0, xmm8, xmm10, 192
         ; iter_51: 6 - 6
         add	r8d, edx
-        rorxl	ebx, r8d, 15
-        rorxl	eax, r8d, 23
-        roll	r14d, 9
+        rorx	ebx, r8d, 15
+        rorx	eax, r8d, 23
+        rol	r14d, 9
         ; iter_51: 7 - 7
         xor	r8d, ebx
-        roll	r10d, 19
+        rol	r10d, 19
         xor	r8d, eax
         ; msg_sched done: 48-51
         ; iter_52: 0 - 7
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+416]
-        rorxl	ecx, r12d, 20
+        rorx	ecx, r12d, 20
         add	edx, r8d
         mov	eax, DWORD PTR [rsp+224]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+208]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -11514,20 +11514,20 @@ L_SM3_AVX1_RORXlen_start:
         add	r11d, ecx
         or	r15d, ebx
         add	r15d, edx
-        rorxl	ebx, r15d, 15
-        rorxl	eax, r15d, 23
-        roll	r13d, 9
+        rorx	ebx, r15d, 15
+        rorx	eax, r15d, 23
+        rol	r13d, 9
         xor	r15d, ebx
-        roll	r9d, 19
+        rol	r9d, 19
         xor	r15d, eax
         ; iter_53: 0 - 7
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+424]
-        rorxl	ecx, r11d, 20
+        rorx	ecx, r11d, 20
         add	edx, r15d
         mov	eax, DWORD PTR [rsp+228]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+212]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -11546,20 +11546,20 @@ L_SM3_AVX1_RORXlen_start:
         add	r10d, ecx
         or	r14d, ebx
         add	r14d, edx
-        rorxl	ebx, r14d, 15
-        rorxl	eax, r14d, 23
-        roll	r12d, 9
+        rorx	ebx, r14d, 15
+        rorx	eax, r14d, 23
+        rol	r12d, 9
         xor	r14d, ebx
-        roll	r8d, 19
+        rol	r8d, 19
         xor	r14d, eax
         ; iter_54: 0 - 7
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+432]
-        rorxl	ecx, r10d, 20
+        rorx	ecx, r10d, 20
         add	edx, r14d
         mov	eax, DWORD PTR [rsp+232]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+216]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -11578,20 +11578,20 @@ L_SM3_AVX1_RORXlen_start:
         add	r9d, ecx
         or	r13d, ebx
         add	r13d, edx
-        rorxl	ebx, r13d, 15
-        rorxl	eax, r13d, 23
-        roll	r11d, 9
+        rorx	ebx, r13d, 15
+        rorx	eax, r13d, 23
+        rol	r11d, 9
         xor	r13d, ebx
-        roll	r15d, 19
+        rol	r15d, 19
         xor	r13d, eax
         ; iter_55: 0 - 7
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+440]
-        rorxl	ecx, r9d, 20
+        rorx	ecx, r9d, 20
         add	edx, r13d
         mov	eax, DWORD PTR [rsp+236]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+220]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -11610,22 +11610,22 @@ L_SM3_AVX1_RORXlen_start:
         add	r8d, ecx
         or	r12d, ebx
         add	r12d, edx
-        rorxl	ebx, r12d, 15
-        rorxl	eax, r12d, 23
-        roll	r10d, 9
+        rorx	ebx, r12d, 15
+        rorx	eax, r12d, 23
+        rol	r10d, 9
         xor	r12d, ebx
-        roll	r14d, 19
+        rol	r14d, 19
         xor	r12d, eax
         ; x0_to_w: 64
         vmovdqu	OWORD PTR [rsp+256], xmm0
         ; iter_56: 0 - 7
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+448]
-        rorxl	ecx, r8d, 20
+        rorx	ecx, r8d, 20
         add	edx, r12d
         mov	eax, DWORD PTR [rsp+240]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+224]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -11644,20 +11644,20 @@ L_SM3_AVX1_RORXlen_start:
         add	r15d, ecx
         or	r11d, ebx
         add	r11d, edx
-        rorxl	ebx, r11d, 15
-        rorxl	eax, r11d, 23
-        roll	r9d, 9
+        rorx	ebx, r11d, 15
+        rorx	eax, r11d, 23
+        rol	r9d, 9
         xor	r11d, ebx
-        roll	r13d, 19
+        rol	r13d, 19
         xor	r11d, eax
         ; iter_57: 0 - 7
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+456]
-        rorxl	ecx, r15d, 20
+        rorx	ecx, r15d, 20
         add	edx, r11d
         mov	eax, DWORD PTR [rsp+244]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+228]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -11676,20 +11676,20 @@ L_SM3_AVX1_RORXlen_start:
         add	r14d, ecx
         or	r10d, ebx
         add	r10d, edx
-        rorxl	ebx, r10d, 15
-        rorxl	eax, r10d, 23
-        roll	r8d, 9
+        rorx	ebx, r10d, 15
+        rorx	eax, r10d, 23
+        rol	r8d, 9
         xor	r10d, ebx
-        roll	r12d, 19
+        rol	r12d, 19
         xor	r10d, eax
         ; iter_58: 0 - 7
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+464]
-        rorxl	ecx, r14d, 20
+        rorx	ecx, r14d, 20
         add	edx, r10d
         mov	eax, DWORD PTR [rsp+248]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+232]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -11708,20 +11708,20 @@ L_SM3_AVX1_RORXlen_start:
         add	r13d, ecx
         or	r9d, ebx
         add	r9d, edx
-        rorxl	ebx, r9d, 15
-        rorxl	eax, r9d, 23
-        roll	r15d, 9
+        rorx	ebx, r9d, 15
+        rorx	eax, r9d, 23
+        rol	r15d, 9
         xor	r9d, ebx
-        roll	r11d, 19
+        rol	r11d, 19
         xor	r9d, eax
         ; iter_59: 0 - 7
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+472]
-        rorxl	ecx, r13d, 20
+        rorx	ecx, r13d, 20
         add	edx, r9d
         mov	eax, DWORD PTR [rsp+252]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+236]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -11740,20 +11740,20 @@ L_SM3_AVX1_RORXlen_start:
         add	r12d, ecx
         or	r8d, ebx
         add	r8d, edx
-        rorxl	ebx, r8d, 15
-        rorxl	eax, r8d, 23
-        roll	r14d, 9
+        rorx	ebx, r8d, 15
+        rorx	eax, r8d, 23
+        rol	r14d, 9
         xor	r8d, ebx
-        roll	r10d, 19
+        rol	r10d, 19
         xor	r8d, eax
         ; iter_60: 0 - 7
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+480]
-        rorxl	ecx, r12d, 20
+        rorx	ecx, r12d, 20
         add	edx, r8d
         mov	eax, DWORD PTR [rsp+256]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+240]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -11772,20 +11772,20 @@ L_SM3_AVX1_RORXlen_start:
         add	r11d, ecx
         or	r15d, ebx
         add	r15d, edx
-        rorxl	ebx, r15d, 15
-        rorxl	eax, r15d, 23
-        roll	r13d, 9
+        rorx	ebx, r15d, 15
+        rorx	eax, r15d, 23
+        rol	r13d, 9
         xor	r15d, ebx
-        roll	r9d, 19
+        rol	r9d, 19
         xor	r15d, eax
         ; iter_61: 0 - 7
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+488]
-        rorxl	ecx, r11d, 20
+        rorx	ecx, r11d, 20
         add	edx, r15d
         mov	eax, DWORD PTR [rsp+260]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+244]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -11804,20 +11804,20 @@ L_SM3_AVX1_RORXlen_start:
         add	r10d, ecx
         or	r14d, ebx
         add	r14d, edx
-        rorxl	ebx, r14d, 15
-        rorxl	eax, r14d, 23
-        roll	r12d, 9
+        rorx	ebx, r14d, 15
+        rorx	eax, r14d, 23
+        rol	r12d, 9
         xor	r14d, ebx
-        roll	r8d, 19
+        rol	r8d, 19
         xor	r14d, eax
         ; iter_62: 0 - 7
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+496]
-        rorxl	ecx, r10d, 20
+        rorx	ecx, r10d, 20
         add	edx, r14d
         mov	eax, DWORD PTR [rsp+264]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+248]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -11836,20 +11836,20 @@ L_SM3_AVX1_RORXlen_start:
         add	r9d, ecx
         or	r13d, ebx
         add	r13d, edx
-        rorxl	ebx, r13d, 15
-        rorxl	eax, r13d, 23
-        roll	r11d, 9
+        rorx	ebx, r13d, 15
+        rorx	eax, r13d, 23
+        rol	r11d, 9
         xor	r13d, ebx
-        roll	r15d, 19
+        rol	r15d, 19
         xor	r13d, eax
         ; iter_63: 0 - 7
         mov	edx, DWORD PTR [ptr_L_SM3_AVX1_RORX_t+504]
-        rorxl	ecx, r9d, 20
+        rorx	ecx, r9d, 20
         add	edx, r13d
         mov	eax, DWORD PTR [rsp+268]
         add	edx, ecx
         mov	ebx, DWORD PTR [rsp+252]
-        roll	edx, 7
+        rol	edx, 7
         xor	ecx, edx
         xor	eax, ebx
         add	edx, ebx
@@ -11868,11 +11868,11 @@ L_SM3_AVX1_RORXlen_start:
         add	r8d, ecx
         or	r12d, ebx
         add	r12d, edx
-        rorxl	ebx, r12d, 15
-        rorxl	eax, r12d, 23
-        roll	r10d, 9
+        rorx	ebx, r12d, 15
+        rorx	eax, r12d, 23
+        rol	r10d, 9
         xor	r12d, ebx
-        roll	r14d, 19
+        rol	r14d, 19
         xor	r12d, eax
         xor	r8d, DWORD PTR [rdi]
         xor	r9d, DWORD PTR [rdi+4]
@@ -11883,7 +11883,7 @@ L_SM3_AVX1_RORXlen_start:
         xor	r14d, DWORD PTR [rdi+24]
         xor	r15d, DWORD PTR [rdi+28]
         add	rbp, 64
-        subl	esi, 64
+        sub	esi, 64
         mov	DWORD PTR [rdi], r8d
         mov	DWORD PTR [rdi+4], r9d
         mov	DWORD PTR [rdi+8], r10d

--- a/sp_sm2_arm64.c
+++ b/sp_sm2_arm64.c
@@ -1,6 +1,6 @@
 /* sp.c
  *
- * Copyright (C) 2006-2023 wolfSSL Inc.
+ * Copyright (C) 2006-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *
@@ -55,6 +55,7 @@
 #ifdef __IAR_SYSTEMS_ICC__
 #define __asm__        asm
 #define __volatile__   volatile
+#define WOLFSSL_NO_VAR_ASSIGN_REG
 #endif /* __IAR_SYSTEMS_ICC__ */
 #ifdef __KEIL__
 #define __asm__        __asm
@@ -66,7 +67,7 @@
     do {                                                    \
         int ii;                                             \
         fprintf(stderr, name "=0x");                        \
-        for (ii = ((bits + 63) / 64) - 1; ii >= 0; ii--)    \
+        for (ii = (((bits) + 63) / 64) - 1; ii >= 0; ii--)  \
             fprintf(stderr, SP_PRINT_FMT, (var)[ii]);       \
         fprintf(stderr, "\n");                              \
     } while (0)
@@ -218,7 +219,8 @@ static void sp_256_mul_sm2_4(sp_digit* r, const sp_digit* a, const sp_digit* b)
  * a  A single precision integer.
  * b  A single precision integer.
  */
-static void sp_256_mul_sm2_4(sp_digit* r, const sp_digit* a, const sp_digit* b)
+SP_NOINLINE static void sp_256_mul_sm2_4(sp_digit* r, const sp_digit* a,
+    const sp_digit* b)
 {
     __asm__ __volatile__ (
         "ldp	x13, x14, [%[a], 0]\n\t"
@@ -324,7 +326,7 @@ static void sp_256_mul_sm2_4(sp_digit* r, const sp_digit* a, const sp_digit* b)
  * r  A single precision integer.
  * a  A single precision integer.
  */
-static void sp_256_sqr_sm2_4(sp_digit* r, const sp_digit* a)
+SP_NOINLINE static void sp_256_sqr_sm2_4(sp_digit* r, const sp_digit* a)
 {
     __asm__ __volatile__ (
         "ldp	x12, x13, [%[a], 0]\n\t"
@@ -1368,8 +1370,8 @@ static void sp_256_mont_sqr_sm2_4(sp_digit* r, const sp_digit* a, const sp_digit
  * m   Modulus (prime).
  * mp  Montgomery multiplier.
  */
-static void sp_256_mont_sqr_n_sm2_4(sp_digit* r, const sp_digit* a, int n,
-        const sp_digit* m, sp_digit mp)
+SP_NOINLINE static void sp_256_mont_sqr_n_sm2_4(sp_digit* r,
+    const sp_digit* a, int n, const sp_digit* m, sp_digit mp)
 {
     sp_256_mont_sqr_sm2_4(r, a, m, mp);
     for (; n > 1; n--) {
@@ -1599,7 +1601,7 @@ static void sp_256_map_sm2_4(sp_point_256* r, const sp_point_256* p,
     sp_256_mont_reduce_sm2_4(r->x, p256_sm2_mod, p256_sm2_mp_mod);
     /* Reduce x to less than modulus */
     n = sp_256_cmp_sm2_4(r->x, p256_sm2_mod);
-    sp_256_cond_sub_sm2_4(r->x, r->x, p256_sm2_mod, ~(n >> 63));
+    sp_256_cond_sub_sm2_4(r->x, r->x, p256_sm2_mod, (sp_digit)~(n >> 63));
     sp_256_norm_4(r->x);
 
     /* y /= z^3 */
@@ -1608,7 +1610,7 @@ static void sp_256_map_sm2_4(sp_point_256* r, const sp_point_256* p,
     sp_256_mont_reduce_sm2_4(r->y, p256_sm2_mod, p256_sm2_mp_mod);
     /* Reduce y to less than modulus */
     n = sp_256_cmp_sm2_4(r->y, p256_sm2_mod);
-    sp_256_cond_sub_sm2_4(r->y, r->y, p256_sm2_mod, ~(n >> 63));
+    sp_256_cond_sub_sm2_4(r->y, r->y, p256_sm2_mod, (sp_digit)~(n >> 63));
     sp_256_norm_4(r->y);
 
     XMEMSET(r->z, 0, sizeof(r->z) / 2);
@@ -1621,7 +1623,8 @@ static void sp_256_map_sm2_4(sp_point_256* r, const sp_point_256* p,
  * a   Number to double in Montgomery form.
  * m   Modulus (prime).
  */
-static void sp_256_mont_dbl_sm2_4(sp_digit* r, const sp_digit* a, const sp_digit* m)
+SP_NOINLINE static void sp_256_mont_dbl_sm2_4(sp_digit* r, const sp_digit* a,
+    const sp_digit* m)
 {
     __asm__ __volatile__ (
         "ldp   x3, x4, [%[a]]\n\t"
@@ -1661,7 +1664,8 @@ static void sp_256_mont_dbl_sm2_4(sp_digit* r, const sp_digit* a, const sp_digit
  * a   Number to triple in Montgomery form.
  * m   Modulus (prime).
  */
-static void sp_256_mont_tpl_sm2_4(sp_digit* r, const sp_digit* a, const sp_digit* m)
+SP_NOINLINE static void sp_256_mont_tpl_sm2_4(sp_digit* r, const sp_digit* a,
+    const sp_digit* m)
 {
     __asm__ __volatile__ (
         "ldp   x9, x10, [%[a]]\n\t"
@@ -1717,8 +1721,8 @@ static void sp_256_mont_tpl_sm2_4(sp_digit* r, const sp_digit* a, const sp_digit
  * b   Number to subtract with in Montgomery form.
  * m   Modulus (prime).
  */
-static void sp_256_mont_sub_sm2_4(sp_digit* r, const sp_digit* a, const sp_digit* b,
-        const sp_digit* m)
+SP_NOINLINE static void sp_256_mont_sub_sm2_4(sp_digit* r, const sp_digit* a,
+    const sp_digit* b, const sp_digit* m)
 {
     __asm__ __volatile__ (
         "ldp   x4, x5, [%[a], 0]\n\t"
@@ -1759,7 +1763,8 @@ static void sp_256_mont_sub_sm2_4(sp_digit* r, const sp_digit* a, const sp_digit
  * a  Number to divide.
  * m  Modulus (prime).
  */
-static void sp_256_mont_div2_sm2_4(sp_digit* r, const sp_digit* a, const sp_digit* m)
+SP_NOINLINE static void sp_256_mont_div2_sm2_4(sp_digit* r, const sp_digit* a,
+    const sp_digit* m)
 {
     __asm__ __volatile__ (
         "ldp   x3, x4, [%[a], 0]\n\t"
@@ -2349,7 +2354,8 @@ static void sp_256_proj_point_add_sm2_4(sp_point_256* r,
         : [r] "r" (r), [p] "r" (p), [q] "r" (q), [x] "r" (x),
           [y] "r" (y), [z] "r" (z)
         : "memory", "x10", "x11", "x12", "x13", "x14", "x15", "x16", "x17",
-          "x19", "x20", "x21", "x22", "x23", "x24", "x25", "x26", "x27", "x28"
+          "x19", "x20", "x21", "x22", "x23", "x24", "x25", "x26", "x27", "x28",
+          "cc"
     );
 }
     }
@@ -2581,7 +2587,8 @@ static int sp_256_proj_point_add_sm2_4_nb(sp_ecc_ctx_t* sp_ctx, sp_point_256* r,
         : [r] "r" (r), [p] "r" (p), [q] "r" (q), [x] "r" (ctx->x),
           [y] "r" (ctx->y), [z] "r" (ctx->z)
         : "memory", "x10", "x11", "x12", "x13", "x14", "x15", "x16", "x17",
-          "x19", "x20", "x21", "x22", "x23", "x24", "x25", "x26", "x27", "x28"
+          "x19", "x20", "x21", "x22", "x23", "x24", "x25", "x26", "x27", "x28",
+          "cc"
     );
 }
         ctx->state = 25;
@@ -2791,7 +2798,7 @@ static void sp_256_ecc_recode_6_4(const sp_digit* k, ecc_recode_256* v)
     n = k[j];
     o = 0;
     for (i=0; i<43; i++) {
-        y = (int8_t)n;
+        y = (uint8_t)(int8_t)n;
         if (o + 6 < 64) {
             y &= 0x3f;
             n >>= 6;
@@ -2824,8 +2831,8 @@ static void sp_256_ecc_recode_6_4(const sp_digit* k, ecc_recode_256* v)
  * table  Table - start of the entries to access
  * idx    Index of entry to retrieve.
  */
-static void sp_256_get_point_33_sm2_4(sp_point_256* r, const sp_point_256* table,
-    int idx)
+SP_NOINLINE static void sp_256_get_point_33_sm2_4(sp_point_256* r,
+    const sp_point_256* table, int idx)
 {
     __asm__ __volatile__ (
         "mov	w30, #1\n\t"
@@ -2882,7 +2889,7 @@ static void sp_256_get_point_33_sm2_4(sp_point_256* r, const sp_point_256* table
         "stp	x13, x14, [%[r], #144]\n\t"
        : [table] "+r" (table)
        : [r] "r" (r), [idx] "r" (idx)
-       : "memory", "x3", "x4", "x5", "x6", "x7", "x8", "x9", "x10", "x11", "x12", "x13", "x14", "x15", "x16", "x17", "x19", "w30"
+       : "memory", "x3", "x4", "x5", "x6", "x7", "x8", "x9", "x10", "x11", "x12", "x13", "x14", "x15", "x16", "x17", "x19", "w30", "cc"
     );
 }
 #endif /* !WC_NO_CACHE_RESISTANT */
@@ -3022,10 +3029,8 @@ static int sp_256_ecc_mulmod_win_add_sub_sm2_4(sp_point_256* r, const sp_point_2
     }
 
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (t != NULL)
-        XFREE(t, heap, DYNAMIC_TYPE_ECC);
-    if (tmp != NULL)
-        XFREE(tmp, heap, DYNAMIC_TYPE_ECC);
+    XFREE(t, heap, DYNAMIC_TYPE_ECC);
+    XFREE(tmp, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -3151,7 +3156,8 @@ static void sp_256_proj_point_add_qz1_sm2_4(sp_point_256* r,
         : [r] "r" (r), [p] "r" (p), [q] "r" (q), [x] "r" (x),
           [y] "r" (y), [z] "r" (z)
         : "memory", "x10", "x11", "x12", "x13", "x14", "x15", "x16", "x17",
-          "x19", "x20", "x21", "x22", "x23", "x24", "x25", "x26", "x27", "x28"
+          "x19", "x20", "x21", "x22", "x23", "x24", "x25", "x26", "x27", "x28",
+          "cc"
     );
 }
     }
@@ -3266,8 +3272,7 @@ static int sp_256_gen_stripe_table_sm2_4(const sp_point_256* a,
     }
 
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (t != NULL)
-        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+    XFREE(t, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -3282,7 +3287,7 @@ static int sp_256_gen_stripe_table_sm2_4(const sp_point_256* a,
  * table  Table - start of the entries to access
  * idx    Index of entry to retrieve.
  */
-static void sp_256_get_entry_64_sm2_4(sp_point_256* r,
+SP_NOINLINE static void sp_256_get_entry_64_sm2_4(sp_point_256* r,
     const sp_table_entry_256* table, int idx)
 {
     __asm__ __volatile__ (
@@ -3326,7 +3331,7 @@ static void sp_256_get_entry_64_sm2_4(sp_point_256* r,
         "stp	x9, x10, [%[r], #80]\n\t"
        : [table] "+r" (table)
        : [r] "r" (r), [idx] "r" (idx)
-       : "memory", "x3", "x4", "x5", "x6", "x7", "x8", "x9", "x10", "x11", "x12", "x13", "x14", "x15", "x16", "x17", "x19", "w30"
+       : "memory", "x3", "x4", "x5", "x6", "x7", "x8", "x9", "x10", "x11", "x12", "x13", "x14", "x15", "x16", "x17", "x19", "w30", "cc"
     );
 }
 #endif /* !WC_NO_CACHE_RESISTANT */
@@ -3437,10 +3442,8 @@ static int sp_256_ecc_mulmod_stripe_sm2_4(sp_point_256* r, const sp_point_256* g
     }
 
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (t != NULL)
-        XFREE(t, heap, DYNAMIC_TYPE_ECC);
-    if (rt != NULL)
-        XFREE(rt, heap, DYNAMIC_TYPE_ECC);
+    XFREE(t, heap, DYNAMIC_TYPE_ECC);
+    XFREE(rt, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -3474,8 +3477,10 @@ static THREAD_LS_T int sp_cache_256_last = -1;
 static THREAD_LS_T int sp_cache_256_inited = 0;
 
 #ifndef HAVE_THREAD_LS
+    #ifndef WOLFSSL_MUTEX_INITIALIZER
     static volatile int initCacheMutex_256 = 0;
-    static wolfSSL_Mutex sp_cache_256_lock;
+    #endif
+    static wolfSSL_Mutex sp_cache_256_lock WOLFSSL_MUTEX_INITIALIZER_CLAUSE(sp_cache_256_lock);
 #endif
 
 /* Get the cache entry for the point.
@@ -3573,10 +3578,12 @@ static int sp_256_ecc_mulmod_sm2_4(sp_point_256* r, const sp_point_256* g,
 #endif
 #ifndef HAVE_THREAD_LS
     if (err == MP_OKAY) {
+        #ifndef WOLFSSL_MUTEX_INITIALIZER
         if (initCacheMutex_256 == 0) {
             wc_InitMutex(&sp_cache_256_lock);
             initCacheMutex_256 = 1;
         }
+        #endif
         if (wc_LockMutex(&sp_cache_256_lock) != 0) {
             err = BAD_MUTEX_E;
         }
@@ -3695,8 +3702,7 @@ static int sp_256_gen_stripe_table_sm2_4(const sp_point_256* a,
     }
 
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (t != NULL)
-        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+    XFREE(t, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -3711,7 +3717,7 @@ static int sp_256_gen_stripe_table_sm2_4(const sp_point_256* a,
  * table  Table - start of the entries to access
  * idx    Index of entry to retrieve.
  */
-static void sp_256_get_entry_256_sm2_4(sp_point_256* r,
+SP_NOINLINE static void sp_256_get_entry_256_sm2_4(sp_point_256* r,
     const sp_table_entry_256* table, int idx)
 {
     __asm__ __volatile__ (
@@ -3755,7 +3761,7 @@ static void sp_256_get_entry_256_sm2_4(sp_point_256* r,
         "stp	x9, x10, [%[r], #80]\n\t"
        : [table] "+r" (table)
        : [r] "r" (r), [idx] "r" (idx)
-       : "memory", "x3", "x4", "x5", "x6", "x7", "x8", "x9", "x10", "x11", "x12", "x13", "x14", "x15", "x16", "x17", "x19", "w30"
+       : "memory", "x3", "x4", "x5", "x6", "x7", "x8", "x9", "x10", "x11", "x12", "x13", "x14", "x15", "x16", "x17", "x19", "w30", "cc"
     );
 }
 #endif /* !WC_NO_CACHE_RESISTANT */
@@ -3866,10 +3872,8 @@ static int sp_256_ecc_mulmod_stripe_sm2_4(sp_point_256* r, const sp_point_256* g
     }
 
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (t != NULL)
-        XFREE(t, heap, DYNAMIC_TYPE_ECC);
-    if (rt != NULL)
-        XFREE(rt, heap, DYNAMIC_TYPE_ECC);
+    XFREE(t, heap, DYNAMIC_TYPE_ECC);
+    XFREE(rt, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -3903,8 +3907,10 @@ static THREAD_LS_T int sp_cache_256_last = -1;
 static THREAD_LS_T int sp_cache_256_inited = 0;
 
 #ifndef HAVE_THREAD_LS
+    #ifndef WOLFSSL_MUTEX_INITIALIZER
     static volatile int initCacheMutex_256 = 0;
-    static wolfSSL_Mutex sp_cache_256_lock;
+    #endif
+    static wolfSSL_Mutex sp_cache_256_lock WOLFSSL_MUTEX_INITIALIZER_CLAUSE(sp_cache_256_lock);
 #endif
 
 /* Get the cache entry for the point.
@@ -4002,10 +4008,12 @@ static int sp_256_ecc_mulmod_sm2_4(sp_point_256* r, const sp_point_256* g,
 #endif
 #ifndef HAVE_THREAD_LS
     if (err == MP_OKAY) {
+        #ifndef WOLFSSL_MUTEX_INITIALIZER
         if (initCacheMutex_256 == 0) {
             wc_InitMutex(&sp_cache_256_lock);
             initCacheMutex_256 = 1;
         }
+        #endif
         if (wc_LockMutex(&sp_cache_256_lock) != 0) {
             err = BAD_MUTEX_E;
         }
@@ -4084,10 +4092,8 @@ int sp_ecc_mulmod_sm2_256(const mp_int* km, const ecc_point* gm, ecc_point* r,
     }
 
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (k != NULL)
-        XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    if (point != NULL)
-        XFREE(point, heap, DYNAMIC_TYPE_ECC);
+    XFREE(k, heap, DYNAMIC_TYPE_ECC);
+    XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -4164,10 +4170,8 @@ int sp_ecc_mulmod_add_sm2_256(const mp_int* km, const ecc_point* gm,
     }
 
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (k != NULL)
-        XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    if (point != NULL)
-        XFREE(point, heap, DYNAMIC_TYPE_ECC);
+    XFREE(k, heap, DYNAMIC_TYPE_ECC);
+    XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -5877,7 +5881,7 @@ static void sp_256_ecc_recode_7_4(const sp_digit* k, ecc_recode_256* v)
     n = k[j];
     o = 0;
     for (i=0; i<37; i++) {
-        y = (int8_t)n;
+        y = (uint8_t)(int8_t)n;
         if (o + 7 < 64) {
             y &= 0x7f;
             n >>= 7;
@@ -5910,7 +5914,7 @@ static void sp_256_ecc_recode_7_4(const sp_digit* k, ecc_recode_256* v)
  * table  Table - start of the entries to access
  * idx    Index of entry to retrieve.
  */
-static void sp_256_get_entry_65_sm2_4(sp_point_256* r,
+SP_NOINLINE static void sp_256_get_entry_65_sm2_4(sp_point_256* r,
     const sp_table_entry_256* table, int idx)
 {
     __asm__ __volatile__ (
@@ -5954,7 +5958,7 @@ static void sp_256_get_entry_65_sm2_4(sp_point_256* r,
         "stp	x9, x10, [%[r], #80]\n\t"
        : [table] "+r" (table)
        : [r] "r" (r), [idx] "r" (idx)
-       : "memory", "x3", "x4", "x5", "x6", "x7", "x8", "x9", "x10", "x11", "x12", "x13", "x14", "x15", "x16", "x17", "x19", "w30"
+       : "memory", "x3", "x4", "x5", "x6", "x7", "x8", "x9", "x10", "x11", "x12", "x13", "x14", "x15", "x16", "x17", "x19", "w30", "cc"
     );
 }
 #endif /* !WC_NO_CACHE_RESISTANT */
@@ -18021,8 +18025,7 @@ static int sp_256_ecc_mulmod_add_only_sm2_4(sp_point_256* r, const sp_point_256*
     #endif
     }
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (rt != NULL)
-        XFREE(rt, heap, DYNAMIC_TYPE_ECC);
+    XFREE(rt, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -18089,10 +18092,8 @@ int sp_ecc_mulmod_base_sm2_256(const mp_int* km, ecc_point* r, int map, void* he
     }
 
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (k != NULL)
-        XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    if (point != NULL)
-        XFREE(point, heap, DYNAMIC_TYPE_ECC);
+    XFREE(k, heap, DYNAMIC_TYPE_ECC);
+    XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -18167,10 +18168,8 @@ int sp_ecc_mulmod_base_add_sm2_256(const mp_int* km, const ecc_point* am,
     }
 
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (k != NULL)
-        XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    if (point)
-        XFREE(point, heap, DYNAMIC_TYPE_ECC);
+    XFREE(k, heap, DYNAMIC_TYPE_ECC);
+    XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -18220,7 +18219,7 @@ static void sp_256_from_bin(sp_digit* r, int size, const byte* a, int n)
         "subs	x6, %[n], 8\n\t"
         "mov	x7, xzr\n\t"
         "blt	2f\n\t"
-        /* Put in mulitples of 8 bytes. */
+        /* Put in multiples of 8 bytes. */
         "1:\n\t"
         "ldr	x8, [x4], -8\n\t"
         "subs	x6, x6, 8\n\t"
@@ -18323,6 +18322,7 @@ static void sp_256_from_bin(sp_digit* r, int size, const byte* a, int n)
  */
 static int sp_256_ecc_gen_k_sm2_4(WC_RNG* rng, sp_digit* k)
 {
+#ifndef WC_NO_RNG
     int err;
     byte buf[32];
 
@@ -18339,6 +18339,11 @@ static int sp_256_ecc_gen_k_sm2_4(WC_RNG* rng, sp_digit* k)
     while (err == 0);
 
     return err;
+#else
+    (void)rng;
+    (void)k;
+    return NOT_COMPILED_IN;
+#endif
 }
 
 /* Makes a random EC key pair.
@@ -18417,12 +18422,9 @@ int sp_ecc_make_key_sm2_256(WC_RNG* rng, mp_int* priv, ecc_point* pub, void* hea
     }
 
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (k != NULL)
-        XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    if (point != NULL) {
-        /* point is not sensitive, so no need to zeroize */
-        XFREE(point, heap, DYNAMIC_TYPE_ECC);
-    }
+    XFREE(k, heap, DYNAMIC_TYPE_ECC);
+    /* point is not sensitive, so no need to zeroize */
+    XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -18586,10 +18588,8 @@ int sp_ecc_secret_gen_sm2_256(const mp_int* priv, const ecc_point* pub, byte* ou
     }
 
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (k != NULL)
-        XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    if (point != NULL)
-        XFREE(point, heap, DYNAMIC_TYPE_ECC);
+    XFREE(k, heap, DYNAMIC_TYPE_ECC);
+    XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -19729,9 +19729,6 @@ int sp_ecc_verify_sm2_256(const byte* hash, word32 hashLen, const mp_int* pX,
         /* (r - e + n*order).z'.z' mod prime == (s.G + t.Q)->x' */
         /* Load e, subtract from r. */
         sp_256_from_bin(e, 4, hash, (int)hashLen);
-        if (sp_256_cmp_sm2_4(r, e) < 0) {
-            carry = sp_256_add_sm2_4(r, r, p256_sm2_order);
-        }
         sp_256_sub_sm2_4(e, r, e);
         sp_256_norm_4(e);
         /* x' == (r - e).z'.z' mod prime */
@@ -19766,8 +19763,8 @@ int sp_ecc_verify_sm2_256(const byte* hash, word32 hashLen, const mp_int* pX,
  * b   Second number to add in Montgomery form.
  * m   Modulus (prime).
  */
-static void sp_256_mont_add_sm2_4(sp_digit* r, const sp_digit* a, const sp_digit* b,
-        const sp_digit* m)
+SP_NOINLINE static void sp_256_mont_add_sm2_4(sp_digit* r, const sp_digit* a,
+    const sp_digit* b, const sp_digit* m)
 {
     __asm__ __volatile__ (
         "ldp   x4, x5, [%[a], 0]\n\t"
@@ -19803,7 +19800,7 @@ static void sp_256_mont_add_sm2_4(sp_digit* r, const sp_digit* a, const sp_digit
     (void)m;
 }
 
-/* Check that the x and y oridinates are a valid point on the curve.
+/* Check that the x and y ordinates are a valid point on the curve.
  *
  * point  EC point.
  * heap   Heap to use if dynamically allocating.
@@ -19852,14 +19849,13 @@ static int sp_256_ecc_is_point_sm2_4(const sp_point_256* point,
     }
 
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (t1 != NULL)
-        XFREE(t1, heap, DYNAMIC_TYPE_ECC);
+    XFREE(t1, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
 }
 
-/* Check that the x and y oridinates are a valid point on the curve.
+/* Check that the x and y ordinates are a valid point on the curve.
  *
  * pX  X ordinate of EC point.
  * pY  Y ordinate of EC point.
@@ -19892,8 +19888,7 @@ int sp_ecc_is_point_sm2_256(const mp_int* pX, const mp_int* pY)
     }
 
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (pub != NULL)
-        XFREE(pub, NULL, DYNAMIC_TYPE_ECC);
+    XFREE(pub, NULL, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -20001,10 +19996,8 @@ int sp_ecc_check_key_sm2_256(const mp_int* pX, const mp_int* pY,
     }
 
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (pub != NULL)
-        XFREE(pub, heap, DYNAMIC_TYPE_ECC);
-    if (priv != NULL)
-        XFREE(priv, heap, DYNAMIC_TYPE_ECC);
+    XFREE(pub, heap, DYNAMIC_TYPE_ECC);
+    XFREE(priv, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -20083,10 +20076,8 @@ int sp_ecc_proj_add_point_sm2_256(mp_int* pX, mp_int* pY, mp_int* pZ,
     }
 
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (tmp != NULL)
-        XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
-    if (p != NULL)
-        XFREE(p, NULL, DYNAMIC_TYPE_ECC);
+    XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
+    XFREE(p, NULL, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -20151,10 +20142,8 @@ int sp_ecc_proj_dbl_point_sm2_256(mp_int* pX, mp_int* pY, mp_int* pZ,
     }
 
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (tmp != NULL)
-        XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
-    if (p != NULL)
-        XFREE(p, NULL, DYNAMIC_TYPE_ECC);
+    XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
+    XFREE(p, NULL, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -20215,10 +20204,8 @@ int sp_ecc_map_sm2_256(mp_int* pX, mp_int* pY, mp_int* pZ)
     }
 
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (tmp != NULL)
-        XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
-    if (p != NULL)
-        XFREE(p, NULL, DYNAMIC_TYPE_ECC);
+    XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
+    XFREE(p, NULL, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -20333,8 +20320,7 @@ int sp_ecc_uncompress_sm2_256(mp_int* xm, int odd, mp_int* ym)
     }
 
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (x != NULL)
-        XFREE(x, NULL, DYNAMIC_TYPE_ECC);
+    XFREE(x, NULL, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;

--- a/sp_sm2_armthumb.c
+++ b/sp_sm2_armthumb.c
@@ -1,6 +1,6 @@
 /* sp.c
  *
- * Copyright (C) 2006-2023 wolfSSL Inc.
+ * Copyright (C) 2006-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *
@@ -55,6 +55,7 @@
 #ifdef __IAR_SYSTEMS_ICC__
 #define __asm__        asm
 #define __volatile__   volatile
+#define WOLFSSL_NO_VAR_ASSIGN_REG
 #endif /* __IAR_SYSTEMS_ICC__ */
 #ifdef __KEIL__
 #define __asm__        __asm
@@ -66,7 +67,7 @@
     do {                                                    \
         int ii;                                             \
         fprintf(stderr, name "=0x");                        \
-        for (ii = ((bits + 31) / 32) - 1; ii >= 0; ii--)    \
+        for (ii = (((bits) + 31) / 32) - 1; ii >= 0; ii--)  \
             fprintf(stderr, SP_PRINT_FMT, (var)[ii]);       \
         fprintf(stderr, "\n");                              \
     } while (0)
@@ -399,7 +400,7 @@ SP_NOINLINE static void sp_256_mul_sm2_8(sp_digit* r, const sp_digit* a,
         "mov	%[b], r10\n\t"
         : [a] "+l" (a), [b] "+l" (b), [tmp] "+l" (tmp)
         :
-        : "memory", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12"
+        : "memory", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12", "cc"
     );
 
     XMEMCPY(r, t, sizeof(t));
@@ -824,7 +825,7 @@ SP_NOINLINE static void sp_256_sqr_sm2_8(sp_digit* r, const sp_digit* a)
         "add	sp, sp, r6\n\t"
         : [r] "+l" (r), [a] "+l" (a)
         :
-        : "memory", "r2", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12"
+        : "memory", "r2", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12", "cc"
     );
 }
 
@@ -897,7 +898,7 @@ SP_NOINLINE static sp_digit sp_256_add_sm2_8(sp_digit* r, const sp_digit* a,
         "movs	%[r], r3\n\t"
         : [r] "+l" (r), [a] "+l" (a), [b] "+l" (b)
         :
-        : "memory", "r3", "r4", "r5", "r6", "r7"
+        : "memory", "r3", "r4", "r5", "r6", "r7", "cc"
     );
     return (uint32_t)(size_t)r;
 }
@@ -989,7 +990,7 @@ SP_NOINLINE static sp_digit sp_256_add_sm2_8(sp_digit* r, const sp_digit* a,
 #endif
         : [r] "+l" (r), [a] "+l" (a), [b] "+l" (b)
         :
-        : "memory", "r3", "r4", "r5", "r6"
+        : "memory", "r3", "r4", "r5", "r6", "cc"
     );
     return (uint32_t)(size_t)r;
 }
@@ -1062,7 +1063,7 @@ SP_NOINLINE static sp_digit sp_256_sub_in_place_sm2_8(sp_digit* a,
         "movs	%[a], r2\n\t"
         : [a] "+l" (a), [b] "+l" (b)
         :
-        : "memory", "r2", "r3", "r4", "r5", "r6", "r7"
+        : "memory", "r2", "r3", "r4", "r5", "r6", "r7", "cc"
     );
     return (uint32_t)(size_t)a;
 }
@@ -1156,7 +1157,7 @@ SP_NOINLINE static sp_digit sp_256_sub_in_place_sm2_8(sp_digit* a,
 #endif
         : [a] "+l" (a), [b] "+l" (b)
         :
-        : "memory", "r2", "r3", "r4", "r5"
+        : "memory", "r2", "r3", "r4", "r5", "cc"
     );
     return (uint32_t)(size_t)a;
 }
@@ -1220,7 +1221,7 @@ SP_NOINLINE static sp_digit sp_256_cond_sub_sm2_8(sp_digit* r,
         "movs	%[r], r4\n\t"
         : [r] "+l" (r), [a] "+l" (a), [b] "+l" (b), [m] "+l" (m)
         :
-        : "memory", "r4", "r5", "r6", "r7", "r8"
+        : "memory", "r4", "r5", "r6", "r7", "r8", "cc"
     );
     return (uint32_t)(size_t)r;
 }
@@ -1407,7 +1408,7 @@ SP_NOINLINE static void sp_256_mul_d_sm2_8(sp_digit* r, const sp_digit* a,
         "str	r3, [%[r]]\n\t"
         : [r] "+l" (r), [a] "+l" (a), [b] "+l" (b)
         :
-        : "memory", "r3", "r4", "r5", "r6", "r7", "r8", "r9"
+        : "memory", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "cc"
     );
 }
 
@@ -2022,7 +2023,7 @@ SP_NOINLINE static sp_digit div_256_word_8(sp_digit d1, sp_digit d0,
         "movs	%[d1], r3\n\t"
         : [d1] "+l" (d1), [d0] "+l" (d0), [div] "+l" (div)
         :
-        : "memory", "r3", "r4", "r5", "r6", "r7", "r8", "r9"
+        : "memory", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "cc"
     );
     return (uint32_t)(size_t)d1;
 }
@@ -2158,7 +2159,7 @@ SP_NOINLINE static sp_int32 sp_256_cmp_sm2_8(const sp_digit* a,
         "movs	%[a], r2\n\t"
         : [a] "+l" (a), [b] "+l" (b)
         :
-        : "memory", "r2", "r3", "r4", "r5", "r6", "r7"
+        : "memory", "r2", "r3", "r4", "r5", "r6", "r7", "cc"
     );
     return (uint32_t)(size_t)a;
 }
@@ -2797,7 +2798,7 @@ SP_NOINLINE static void sp_256_mont_reduce_sm2_8(sp_digit* a, const sp_digit* m,
         "str	r7, [%[a], #28]\n\t"
         : [a] "+l" (a)
         :
-        : "memory", "r1", "r2", "r3", "r4", "r5", "r6", "r7", "r8"
+        : "memory", "r1", "r2", "r3", "r4", "r5", "r6", "r7", "r8", "cc"
     );
 }
 
@@ -3455,7 +3456,7 @@ SP_NOINLINE static void sp_256_mont_reduce_order_sm2_8(sp_digit* a,
 #endif /* WOLFSSL_SP_LARGE_CODE */
         : [a] "+l" (a), [m] "+l" (m), [mp] "+l" (mp)
         :
-        : "memory", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12", "lr"
+        : "memory", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12", "lr", "cc"
     );
 }
 
@@ -3498,8 +3499,8 @@ SP_NOINLINE static void sp_256_mont_sqr_sm2_8(sp_digit* r, const sp_digit* a,
  * m   Modulus (prime).
  * mp  Montgomery multiplier.
  */
-static void sp_256_mont_sqr_n_sm2_8(sp_digit* r, const sp_digit* a, int n,
-        const sp_digit* m, sp_digit mp)
+SP_NOINLINE static void sp_256_mont_sqr_n_sm2_8(sp_digit* r,
+    const sp_digit* a, int n, const sp_digit* m, sp_digit mp)
 {
     sp_256_mont_sqr_sm2_8(r, a, m, mp);
     for (; n > 1; n--) {
@@ -3628,7 +3629,7 @@ static void sp_256_map_sm2_8(sp_point_256* r, const sp_point_256* p,
     sp_256_mont_reduce_sm2_8(r->x, p256_sm2_mod, p256_sm2_mp_mod);
     /* Reduce x to less than modulus */
     n = sp_256_cmp_sm2_8(r->x, p256_sm2_mod);
-    sp_256_cond_sub_sm2_8(r->x, r->x, p256_sm2_mod, ~(n >> 31));
+    sp_256_cond_sub_sm2_8(r->x, r->x, p256_sm2_mod, (sp_digit)~(n >> 31));
     sp_256_norm_8(r->x);
 
     /* y /= z^3 */
@@ -3637,7 +3638,7 @@ static void sp_256_map_sm2_8(sp_point_256* r, const sp_point_256* p,
     sp_256_mont_reduce_sm2_8(r->y, p256_sm2_mod, p256_sm2_mp_mod);
     /* Reduce y to less than modulus */
     n = sp_256_cmp_sm2_8(r->y, p256_sm2_mod);
-    sp_256_cond_sub_sm2_8(r->y, r->y, p256_sm2_mod, ~(n >> 31));
+    sp_256_cond_sub_sm2_8(r->y, r->y, p256_sm2_mod, (sp_digit)~(n >> 31));
     sp_256_norm_8(r->y);
 
     XMEMSET(r->z, 0, sizeof(r->z) / 2);
@@ -3830,7 +3831,7 @@ SP_NOINLINE static void sp_256_mont_add_sm2_8(sp_digit* r, const sp_digit* a,
         "str	r5, [%[r], #28]\n\t"
         : [r] "+l" (r), [a] "+l" (a), [b] "+l" (b)
         :
-        : "memory", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11"
+        : "memory", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "cc"
     );
 }
 
@@ -4011,7 +4012,7 @@ SP_NOINLINE static void sp_256_mont_dbl_sm2_8(sp_digit* r, const sp_digit* a,
         "str	r5, [%[r], #28]\n\t"
         : [r] "+l" (r), [a] "+l" (a)
         :
-        : "memory", "r2", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11"
+        : "memory", "r2", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "cc"
     );
 }
 
@@ -4352,7 +4353,7 @@ SP_NOINLINE static void sp_256_mont_tpl_sm2_8(sp_digit* r, const sp_digit* a,
         "str	r2, [%[r], #28]\n\t"
         : [r] "+l" (r), [a] "+l" (a)
         :
-        : "memory", "r2", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12", "lr"
+        : "memory", "r2", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12", "lr", "cc"
     );
 }
 
@@ -4531,7 +4532,7 @@ SP_NOINLINE static void sp_256_mont_sub_sm2_8(sp_digit* r, const sp_digit* a,
         "str	r5, [%[r], #28]\n\t"
         : [r] "+l" (r), [a] "+l" (a), [b] "+l" (b)
         :
-        : "memory", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11"
+        : "memory", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "cc"
     );
 }
 
@@ -4807,7 +4808,7 @@ SP_NOINLINE static void sp_256_mont_div2_sm2_8(sp_digit* r, const sp_digit* a,
         "str	r5, [%[r], #4]\n\t"
         : [r] "+l" (r), [a] "+l" (a)
         :
-        : "memory", "r2", "r3", "r4", "r5", "r6"
+        : "memory", "r2", "r3", "r4", "r5", "r6", "cc"
     );
 }
 
@@ -5102,8 +5103,8 @@ static void sp_256_proj_point_add_sm2_8(sp_point_256* r,
         sp_256_mont_sub_sm2_8(y, y, t5, p256_sm2_mod);
         {
             int i;
-            sp_digit maskp = 0 - (q->infinity & (!p->infinity));
-            sp_digit maskq = 0 - (p->infinity & (!q->infinity));
+            sp_digit maskp = (sp_digit)(0 - (q->infinity & (!p->infinity)));
+            sp_digit maskq = (sp_digit)(0 - (p->infinity & (!q->infinity)));
             sp_digit maskt = ~(maskp | maskq);
             sp_digit inf = (sp_digit)(p->infinity & q->infinity);
 
@@ -5120,7 +5121,7 @@ static void sp_256_proj_point_add_sm2_8(sp_point_256* r,
                           (z[i] & maskt);
             }
             r->z[0] |= inf;
-            r->infinity = (word32)inf;
+            r->infinity = (int)inf;
         }
     }
 }
@@ -5294,8 +5295,8 @@ static int sp_256_proj_point_add_sm2_8_nb(sp_ecc_ctx_t* sp_ctx, sp_point_256* r,
     {
         {
             int i;
-            sp_digit maskp = 0 - (q->infinity & (!p->infinity));
-            sp_digit maskq = 0 - (p->infinity & (!q->infinity));
+            sp_digit maskp = (sp_digit)(0 - (q->infinity & (!p->infinity)));
+            sp_digit maskq = (sp_digit)(0 - (p->infinity & (!q->infinity)));
             sp_digit maskt = ~(maskp | maskq);
             sp_digit inf = (sp_digit)(p->infinity & q->infinity);
 
@@ -5312,7 +5313,7 @@ static int sp_256_proj_point_add_sm2_8_nb(sp_ecc_ctx_t* sp_ctx, sp_point_256* r,
                           (ctx->z[i] & maskt);
             }
             r->z[0] |= inf;
-            r->infinity = (word32)inf;
+            r->infinity = (int)inf;
         }
         ctx->state = 25;
         break;
@@ -5367,7 +5368,7 @@ static void sp_256_get_point_16_sm2_8(sp_point_256* r, const sp_point_256* table
     r->z[6] = 0;
     r->z[7] = 0;
     for (i = 1; i < 16; i++) {
-        mask = 0 - (i == idx);
+        mask = (sp_digit)0 - (i == idx);
         r->x[0] |= mask & table[i].x[0];
         r->x[1] |= mask & table[i].x[1];
         r->x[2] |= mask & table[i].x[2];
@@ -5561,15 +5562,15 @@ static int sp_256_ecc_mulmod_fast_sm2_8(sp_point_256* r, const sp_point_256* g, 
     #endif
     }
 #ifndef WC_NO_CACHE_RESISTANT
-    #ifdef WOLFSSL_SP_SMALL_STACK
+#ifdef WOLFSSL_SP_SMALL_STACK
     if (p != NULL)
+#endif
+    {
+        ForceZero(p, sizeof(sp_point_256));
+    #ifdef WOLFSSL_SP_SMALL_STACK
+        XFREE(p, heap, DYNAMIC_TYPE_ECC);
     #endif
-        {
-            ForceZero(p, sizeof(sp_point_256));
-        #ifdef WOLFSSL_SP_SMALL_STACK
-            XFREE(p, heap, DYNAMIC_TYPE_ECC);
-        #endif
-        }
+    }
 #endif /* !WC_NO_CACHE_RESISTANT */
 #ifdef WOLFSSL_SP_SMALL_STACK
     if (t != NULL)
@@ -5765,8 +5766,8 @@ static void sp_256_proj_point_add_qz1_sm2_8(sp_point_256* r,
         sp_256_mont_sub_sm2_8(y, t3, t1, p256_sm2_mod);
         {
             int i;
-            sp_digit maskp = 0 - (q->infinity & (!p->infinity));
-            sp_digit maskq = 0 - (p->infinity & (!q->infinity));
+            sp_digit maskp = (sp_digit)(0 - (q->infinity & (!p->infinity)));
+            sp_digit maskq = (sp_digit)(0 - (p->infinity & (!q->infinity)));
             sp_digit maskt = ~(maskp | maskq);
             sp_digit inf = (sp_digit)(p->infinity & q->infinity);
 
@@ -5783,7 +5784,7 @@ static void sp_256_proj_point_add_qz1_sm2_8(sp_point_256* r,
                           (z[i] & maskt);
             }
             r->z[0] |= inf;
-            r->infinity = (word32)inf;
+            r->infinity = (int)inf;
         }
     }
 }
@@ -5873,8 +5874,7 @@ static int sp_256_gen_stripe_table_sm2_8(const sp_point_256* a,
     }
 
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (t != NULL)
-        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+    XFREE(t, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -5911,7 +5911,7 @@ static void sp_256_get_entry_16_sm2_8(sp_point_256* r,
     r->y[6] = 0;
     r->y[7] = 0;
     for (i = 1; i < 16; i++) {
-        mask = 0 - (i == idx);
+        mask = (sp_digit)0 - (i == idx);
         r->x[0] |= mask & table[i].x[0];
         r->x[1] |= mask & table[i].x[1];
         r->x[2] |= mask & table[i].x[2];
@@ -6038,10 +6038,8 @@ static int sp_256_ecc_mulmod_stripe_sm2_8(sp_point_256* r, const sp_point_256* g
     }
 
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (t != NULL)
-        XFREE(t, heap, DYNAMIC_TYPE_ECC);
-    if (rt != NULL)
-        XFREE(rt, heap, DYNAMIC_TYPE_ECC);
+    XFREE(t, heap, DYNAMIC_TYPE_ECC);
+    XFREE(rt, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -6074,8 +6072,10 @@ static THREAD_LS_T int sp_cache_256_last = -1;
 static THREAD_LS_T int sp_cache_256_inited = 0;
 
 #ifndef HAVE_THREAD_LS
+    #ifndef WOLFSSL_MUTEX_INITIALIZER
     static volatile int initCacheMutex_256 = 0;
-    static wolfSSL_Mutex sp_cache_256_lock;
+    #endif
+    static wolfSSL_Mutex sp_cache_256_lock WOLFSSL_MUTEX_INITIALIZER_CLAUSE(sp_cache_256_lock);
 #endif
 
 /* Get the cache entry for the point.
@@ -6173,10 +6173,12 @@ static int sp_256_ecc_mulmod_sm2_8(sp_point_256* r, const sp_point_256* g,
 #endif
 #ifndef HAVE_THREAD_LS
     if (err == MP_OKAY) {
+        #ifndef WOLFSSL_MUTEX_INITIALIZER
         if (initCacheMutex_256 == 0) {
             wc_InitMutex(&sp_cache_256_lock);
             initCacheMutex_256 = 1;
         }
+        #endif
         if (wc_LockMutex(&sp_cache_256_lock) != 0) {
             err = BAD_MUTEX_E;
         }
@@ -6293,8 +6295,7 @@ static int sp_256_gen_stripe_table_sm2_8(const sp_point_256* a,
     }
 
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (t != NULL)
-        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+    XFREE(t, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -6331,7 +6332,7 @@ static void sp_256_get_entry_256_sm2_8(sp_point_256* r,
     r->y[6] = 0;
     r->y[7] = 0;
     for (i = 1; i < 256; i++) {
-        mask = 0 - (i == idx);
+        mask = (sp_digit)0 - (i == idx);
         r->x[0] |= mask & table[i].x[0];
         r->x[1] |= mask & table[i].x[1];
         r->x[2] |= mask & table[i].x[2];
@@ -6458,10 +6459,8 @@ static int sp_256_ecc_mulmod_stripe_sm2_8(sp_point_256* r, const sp_point_256* g
     }
 
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (t != NULL)
-        XFREE(t, heap, DYNAMIC_TYPE_ECC);
-    if (rt != NULL)
-        XFREE(rt, heap, DYNAMIC_TYPE_ECC);
+    XFREE(t, heap, DYNAMIC_TYPE_ECC);
+    XFREE(rt, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -6494,8 +6493,10 @@ static THREAD_LS_T int sp_cache_256_last = -1;
 static THREAD_LS_T int sp_cache_256_inited = 0;
 
 #ifndef HAVE_THREAD_LS
+    #ifndef WOLFSSL_MUTEX_INITIALIZER
     static volatile int initCacheMutex_256 = 0;
-    static wolfSSL_Mutex sp_cache_256_lock;
+    #endif
+    static wolfSSL_Mutex sp_cache_256_lock WOLFSSL_MUTEX_INITIALIZER_CLAUSE(sp_cache_256_lock);
 #endif
 
 /* Get the cache entry for the point.
@@ -6593,10 +6594,12 @@ static int sp_256_ecc_mulmod_sm2_8(sp_point_256* r, const sp_point_256* g,
 #endif
 #ifndef HAVE_THREAD_LS
     if (err == MP_OKAY) {
+        #ifndef WOLFSSL_MUTEX_INITIALIZER
         if (initCacheMutex_256 == 0) {
             wc_InitMutex(&sp_cache_256_lock);
             initCacheMutex_256 = 1;
         }
+        #endif
         if (wc_LockMutex(&sp_cache_256_lock) != 0) {
             err = BAD_MUTEX_E;
         }
@@ -6675,10 +6678,8 @@ int sp_ecc_mulmod_sm2_256(const mp_int* km, const ecc_point* gm, ecc_point* r,
     }
 
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (k != NULL)
-        XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    if (point != NULL)
-        XFREE(point, heap, DYNAMIC_TYPE_ECC);
+    XFREE(k, heap, DYNAMIC_TYPE_ECC);
+    XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -6755,10 +6756,8 @@ int sp_ecc_mulmod_add_sm2_256(const mp_int* km, const ecc_point* gm,
     }
 
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (k != NULL)
-        XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    if (point != NULL)
-        XFREE(point, heap, DYNAMIC_TYPE_ECC);
+    XFREE(k, heap, DYNAMIC_TYPE_ECC);
+    XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -8225,10 +8224,8 @@ int sp_ecc_mulmod_base_sm2_256(const mp_int* km, ecc_point* r, int map, void* he
     }
 
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (k != NULL)
-        XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    if (point != NULL)
-        XFREE(point, heap, DYNAMIC_TYPE_ECC);
+    XFREE(k, heap, DYNAMIC_TYPE_ECC);
+    XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -8303,10 +8300,8 @@ int sp_ecc_mulmod_base_add_sm2_256(const mp_int* km, const ecc_point* am,
     }
 
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (k != NULL)
-        XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    if (point)
-        XFREE(point, heap, DYNAMIC_TYPE_ECC);
+    XFREE(k, heap, DYNAMIC_TYPE_ECC);
+    XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -8396,7 +8391,7 @@ SP_NOINLINE static void sp_256_add_one_sm2_8(sp_digit* a)
         "str	r1, [%[a], #28]\n\t"
         : [a] "+l" (a)
         :
-        : "memory", "r1", "r2"
+        : "memory", "r1", "r2", "cc"
     );
 }
 
@@ -8447,6 +8442,7 @@ static void sp_256_from_bin(sp_digit* r, int size, const byte* a, int n)
  */
 static int sp_256_ecc_gen_k_sm2_8(WC_RNG* rng, sp_digit* k)
 {
+#ifndef WC_NO_RNG
     int err;
     byte buf[32];
 
@@ -8463,6 +8459,11 @@ static int sp_256_ecc_gen_k_sm2_8(WC_RNG* rng, sp_digit* k)
     while (err == 0);
 
     return err;
+#else
+    (void)rng;
+    (void)k;
+    return NOT_COMPILED_IN;
+#endif
 }
 
 /* Makes a random EC key pair.
@@ -8541,12 +8542,9 @@ int sp_ecc_make_key_sm2_256(WC_RNG* rng, mp_int* priv, ecc_point* pub, void* hea
     }
 
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (k != NULL)
-        XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    if (point != NULL) {
-        /* point is not sensitive, so no need to zeroize */
-        XFREE(point, heap, DYNAMIC_TYPE_ECC);
-    }
+    XFREE(k, heap, DYNAMIC_TYPE_ECC);
+    /* point is not sensitive, so no need to zeroize */
+    XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -8704,10 +8702,8 @@ int sp_ecc_secret_gen_sm2_256(const mp_int* priv, const ecc_point* pub, byte* ou
     }
 
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (k != NULL)
-        XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    if (point != NULL)
-        XFREE(point, heap, DYNAMIC_TYPE_ECC);
+    XFREE(k, heap, DYNAMIC_TYPE_ECC);
+    XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -8828,7 +8824,7 @@ SP_NOINLINE static sp_digit sp_256_sub_sm2_8(sp_digit* r, const sp_digit* a,
         "movs	%[r], r3\n\t"
         : [r] "+l" (r), [a] "+l" (a), [b] "+l" (b)
         :
-        : "memory", "r3", "r4", "r5", "r6"
+        : "memory", "r3", "r4", "r5", "r6", "cc"
     );
     return (uint32_t)(size_t)r;
 }
@@ -8919,7 +8915,7 @@ SP_NOINLINE static sp_digit sp_256_sub_sm2_8(sp_digit* r, const sp_digit* a,
 #endif
         : [r] "+l" (r), [a] "+l" (a), [b] "+l" (b)
         :
-        : "memory", "r3", "r4", "r5", "r6"
+        : "memory", "r3", "r4", "r5", "r6", "cc"
     );
     return (uint32_t)(size_t)r;
 }
@@ -8992,7 +8988,7 @@ SP_NOINLINE static sp_digit sp_256_cond_add_sm2_8(sp_digit* r,
         "movs	%[r], r4\n\t"
         : [r] "+l" (r), [a] "+l" (a), [b] "+l" (b), [m] "+l" (m)
         :
-        : "memory", "r4", "r5", "r6", "r7", "r8"
+        : "memory", "r4", "r5", "r6", "r7", "r8", "cc"
     );
     return (uint32_t)(size_t)r;
 }
@@ -9455,9 +9451,6 @@ int sp_ecc_verify_sm2_256(const byte* hash, word32 hashLen, const mp_int* pX,
         /* (r - e + n*order).z'.z' mod prime == (s.G + t.Q)->x' */
         /* Load e, subtract from r. */
         sp_256_from_bin(e, 8, hash, (int)hashLen);
-        if (sp_256_cmp_sm2_8(r, e) < 0) {
-            carry = sp_256_add_sm2_8(r, r, p256_sm2_order);
-        }
         sp_256_sub_sm2_8(e, r, e);
         sp_256_norm_8(e);
         /* x' == (r - e).z'.z' mod prime */
@@ -9485,7 +9478,7 @@ int sp_ecc_verify_sm2_256(const byte* hash, word32 hashLen, const mp_int* pX,
 #endif /* HAVE_ECC_VERIFY */
 
 #ifdef HAVE_ECC_CHECK_KEY
-/* Check that the x and y oridinates are a valid point on the curve.
+/* Check that the x and y ordinates are a valid point on the curve.
  *
  * point  EC point.
  * heap   Heap to use if dynamically allocating.
@@ -9534,14 +9527,13 @@ static int sp_256_ecc_is_point_sm2_8(const sp_point_256* point,
     }
 
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (t1 != NULL)
-        XFREE(t1, heap, DYNAMIC_TYPE_ECC);
+    XFREE(t1, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
 }
 
-/* Check that the x and y oridinates are a valid point on the curve.
+/* Check that the x and y ordinates are a valid point on the curve.
  *
  * pX  X ordinate of EC point.
  * pY  Y ordinate of EC point.
@@ -9574,8 +9566,7 @@ int sp_ecc_is_point_sm2_256(const mp_int* pX, const mp_int* pY)
     }
 
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (pub != NULL)
-        XFREE(pub, NULL, DYNAMIC_TYPE_ECC);
+    XFREE(pub, NULL, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -9683,10 +9674,8 @@ int sp_ecc_check_key_sm2_256(const mp_int* pX, const mp_int* pY,
     }
 
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (pub != NULL)
-        XFREE(pub, heap, DYNAMIC_TYPE_ECC);
-    if (priv != NULL)
-        XFREE(priv, heap, DYNAMIC_TYPE_ECC);
+    XFREE(pub, heap, DYNAMIC_TYPE_ECC);
+    XFREE(priv, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -9765,10 +9754,8 @@ int sp_ecc_proj_add_point_sm2_256(mp_int* pX, mp_int* pY, mp_int* pZ,
     }
 
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (tmp != NULL)
-        XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
-    if (p != NULL)
-        XFREE(p, NULL, DYNAMIC_TYPE_ECC);
+    XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
+    XFREE(p, NULL, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -9833,10 +9820,8 @@ int sp_ecc_proj_dbl_point_sm2_256(mp_int* pX, mp_int* pY, mp_int* pZ,
     }
 
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (tmp != NULL)
-        XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
-    if (p != NULL)
-        XFREE(p, NULL, DYNAMIC_TYPE_ECC);
+    XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
+    XFREE(p, NULL, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -9897,10 +9882,8 @@ int sp_ecc_map_sm2_256(mp_int* pX, mp_int* pY, mp_int* pZ)
     }
 
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (tmp != NULL)
-        XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
-    if (p != NULL)
-        XFREE(p, NULL, DYNAMIC_TYPE_ECC);
+    XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
+    XFREE(p, NULL, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -10015,8 +9998,7 @@ int sp_ecc_uncompress_sm2_256(mp_int* xm, int odd, mp_int* ym)
     }
 
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (x != NULL)
-        XFREE(x, NULL, DYNAMIC_TYPE_ECC);
+    XFREE(x, NULL, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;

--- a/sp_sm2_c64.c
+++ b/sp_sm2_c64.c
@@ -1,6 +1,6 @@
 /* sp.c
  *
- * Copyright (C) 2006-2023 wolfSSL Inc.
+ * Copyright (C) 2006-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *
@@ -59,6 +59,7 @@
 #ifdef __IAR_SYSTEMS_ICC__
 #define __asm__        asm
 #define __volatile__   volatile
+#define WOLFSSL_NO_VAR_ASSIGN_REG
 #endif /* __IAR_SYSTEMS_ICC__ */
 #ifdef __KEIL__
 #define __asm__        __asm
@@ -70,13 +71,13 @@
 #define SP_PRINT_NUM(var, name, total, words, bits)   \
     do {                                              \
         int ii;                                       \
-        byte nb[(bits + 7) / 8];                      \
+        byte nb[((bits) + 7) / 8];                    \
         sp_digit _s[words];                           \
         XMEMCPY(_s, var, sizeof(_s));                 \
         sp_##total##_norm_##words(_s);                \
         sp_##total##_to_bin_##words(_s, nb);          \
         fprintf(stderr, name "=0x");                  \
-        for (ii=0; ii<(bits + 7) / 8; ii++)           \
+        for (ii=0; ii<((bits) + 7) / 8; ii++)         \
             fprintf(stderr, "%02x", nb[ii]);          \
         fprintf(stderr, "\n");                        \
     } while (0)
@@ -854,8 +855,8 @@ SP_NOINLINE static void sp_256_mont_sqr_sm2_5(sp_digit* r, const sp_digit* a,
  * m   Modulus (prime).
  * mp  Montgomery multiplier.
  */
-static void sp_256_mont_sqr_n_sm2_5(sp_digit* r, const sp_digit* a, int n,
-        const sp_digit* m, sp_digit mp)
+SP_NOINLINE static void sp_256_mont_sqr_n_sm2_5(sp_digit* r,
+    const sp_digit* a, int n, const sp_digit* m, sp_digit mp)
 {
     sp_256_mont_sqr_sm2_5(r, a, m, mp);
     for (; n > 1; n--) {
@@ -978,7 +979,7 @@ static void sp_256_map_sm2_5(sp_point_256* r, const sp_point_256* p,
     sp_256_mont_reduce_sm2_5(r->x, p256_sm2_mod, p256_sm2_mp_mod);
     /* Reduce x to less than modulus */
     n = sp_256_cmp_sm2_5(r->x, p256_sm2_mod);
-    sp_256_cond_sub_sm2_5(r->x, r->x, p256_sm2_mod, ~(n >> 51));
+    sp_256_cond_sub_sm2_5(r->x, r->x, p256_sm2_mod, (sp_digit)~(n >> 51));
     sp_256_norm_5(r->x);
 
     /* y /= z^3 */
@@ -987,7 +988,7 @@ static void sp_256_map_sm2_5(sp_point_256* r, const sp_point_256* p,
     sp_256_mont_reduce_sm2_5(r->y, p256_sm2_mod, p256_sm2_mp_mod);
     /* Reduce y to less than modulus */
     n = sp_256_cmp_sm2_5(r->y, p256_sm2_mod);
-    sp_256_cond_sub_sm2_5(r->y, r->y, p256_sm2_mod, ~(n >> 51));
+    sp_256_cond_sub_sm2_5(r->y, r->y, p256_sm2_mod, (sp_digit)~(n >> 51));
     sp_256_norm_5(r->y);
 
     XMEMSET(r->z, 0, sizeof(r->z) / 2);
@@ -1432,8 +1433,8 @@ static void sp_256_proj_point_add_sm2_5(sp_point_256* r,
         sp_256_mont_sub_sm2_5(y, y, t5, p256_sm2_mod);
         {
             int i;
-            sp_digit maskp = 0 - (q->infinity & (!p->infinity));
-            sp_digit maskq = 0 - (p->infinity & (!q->infinity));
+            sp_digit maskp = (sp_digit)(0 - (q->infinity & (!p->infinity)));
+            sp_digit maskq = (sp_digit)(0 - (p->infinity & (!q->infinity)));
             sp_digit maskt = ~(maskp | maskq);
             sp_digit inf = (sp_digit)(p->infinity & q->infinity);
 
@@ -1450,7 +1451,7 @@ static void sp_256_proj_point_add_sm2_5(sp_point_256* r,
                           (z[i] & maskt);
             }
             r->z[0] |= inf;
-            r->infinity = (word32)inf;
+            r->infinity = (int)inf;
         }
     }
 }
@@ -1624,8 +1625,8 @@ static int sp_256_proj_point_add_sm2_5_nb(sp_ecc_ctx_t* sp_ctx, sp_point_256* r,
     {
         {
             int i;
-            sp_digit maskp = 0 - (q->infinity & (!p->infinity));
-            sp_digit maskq = 0 - (p->infinity & (!q->infinity));
+            sp_digit maskp = (sp_digit)(0 - (q->infinity & (!p->infinity)));
+            sp_digit maskq = (sp_digit)(0 - (p->infinity & (!q->infinity)));
             sp_digit maskt = ~(maskp | maskq);
             sp_digit inf = (sp_digit)(p->infinity & q->infinity);
 
@@ -1642,7 +1643,7 @@ static int sp_256_proj_point_add_sm2_5_nb(sp_ecc_ctx_t* sp_ctx, sp_point_256* r,
                           (ctx->z[i] & maskt);
             }
             r->z[0] |= inf;
-            r->infinity = (word32)inf;
+            r->infinity = (int)inf;
         }
         ctx->state = 25;
         break;
@@ -1945,8 +1946,7 @@ static int sp_256_div_sm2_5(const sp_digit* a, const sp_digit* d,
     }
 
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (t1 != NULL)
-        XFREE(t1, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    XFREE(t1, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 #endif
 
     return err;
@@ -2539,7 +2539,7 @@ static void sp_256_ecc_recode_6_5(const sp_digit* k, ecc_recode_256* v)
     n = k[j];
     o = 0;
     for (i=0; i<43; i++) {
-        y = (int8_t)n;
+        y = (uint8_t)(int8_t)n;
         if (o + 6 < 52) {
             y &= 0x3f;
             n >>= 6;
@@ -2594,7 +2594,7 @@ static void sp_256_get_point_33_sm2_5(sp_point_256* r, const sp_point_256* table
     r->z[3] = 0;
     r->z[4] = 0;
     for (i = 1; i < 33; i++) {
-        mask = 0 - (i == idx);
+        mask = (sp_digit)0 - (i == idx);
         r->x[0] |= mask & table[i].x[0];
         r->x[1] |= mask & table[i].x[1];
         r->x[2] |= mask & table[i].x[2];
@@ -2749,10 +2749,8 @@ static int sp_256_ecc_mulmod_win_add_sub_sm2_5(sp_point_256* r, const sp_point_2
     }
 
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (t != NULL)
-        XFREE(t, heap, DYNAMIC_TYPE_ECC);
-    if (tmp != NULL)
-        XFREE(tmp, heap, DYNAMIC_TYPE_ECC);
+    XFREE(t, heap, DYNAMIC_TYPE_ECC);
+    XFREE(tmp, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -2818,8 +2816,8 @@ static void sp_256_proj_point_add_qz1_sm2_5(sp_point_256* r,
         sp_256_mont_sub_sm2_5(y, t3, t1, p256_sm2_mod);
         {
             int i;
-            sp_digit maskp = 0 - (q->infinity & (!p->infinity));
-            sp_digit maskq = 0 - (p->infinity & (!q->infinity));
+            sp_digit maskp = (sp_digit)(0 - (q->infinity & (!p->infinity)));
+            sp_digit maskq = (sp_digit)(0 - (p->infinity & (!q->infinity)));
             sp_digit maskt = ~(maskp | maskq);
             sp_digit inf = (sp_digit)(p->infinity & q->infinity);
 
@@ -2836,7 +2834,7 @@ static void sp_256_proj_point_add_qz1_sm2_5(sp_point_256* r,
                           (z[i] & maskt);
             }
             r->z[0] |= inf;
-            r->infinity = (word32)inf;
+            r->infinity = (int)inf;
         }
     }
 }
@@ -2947,8 +2945,7 @@ static int sp_256_gen_stripe_table_sm2_5(const sp_point_256* a,
     }
 
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (t != NULL)
-        XFREE(t, heap, DYNAMIC_TYPE_ECC);
+    XFREE(t, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -2979,7 +2976,7 @@ static void sp_256_get_entry_256_sm2_5(sp_point_256* r,
     r->y[3] = 0;
     r->y[4] = 0;
     for (i = 1; i < 256; i++) {
-        mask = 0 - (i == idx);
+        mask = (sp_digit)0 - (i == idx);
         r->x[0] |= mask & table[i].x[0];
         r->x[1] |= mask & table[i].x[1];
         r->x[2] |= mask & table[i].x[2];
@@ -3100,10 +3097,8 @@ static int sp_256_ecc_mulmod_stripe_sm2_5(sp_point_256* r, const sp_point_256* g
     }
 
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (t != NULL)
-        XFREE(t, heap, DYNAMIC_TYPE_ECC);
-    if (rt != NULL)
-        XFREE(rt, heap, DYNAMIC_TYPE_ECC);
+    XFREE(t, heap, DYNAMIC_TYPE_ECC);
+    XFREE(rt, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -3136,8 +3131,10 @@ static THREAD_LS_T int sp_cache_256_last = -1;
 static THREAD_LS_T int sp_cache_256_inited = 0;
 
 #ifndef HAVE_THREAD_LS
+    #ifndef WOLFSSL_MUTEX_INITIALIZER
     static volatile int initCacheMutex_256 = 0;
-    static wolfSSL_Mutex sp_cache_256_lock;
+    #endif
+    static wolfSSL_Mutex sp_cache_256_lock WOLFSSL_MUTEX_INITIALIZER_CLAUSE(sp_cache_256_lock);
 #endif
 
 /* Get the cache entry for the point.
@@ -3235,10 +3232,12 @@ static int sp_256_ecc_mulmod_sm2_5(sp_point_256* r, const sp_point_256* g,
 #endif
 #ifndef HAVE_THREAD_LS
     if (err == MP_OKAY) {
+        #ifndef WOLFSSL_MUTEX_INITIALIZER
         if (initCacheMutex_256 == 0) {
             wc_InitMutex(&sp_cache_256_lock);
             initCacheMutex_256 = 1;
         }
+        #endif
         if (wc_LockMutex(&sp_cache_256_lock) != 0) {
             err = BAD_MUTEX_E;
         }
@@ -3317,10 +3316,8 @@ int sp_ecc_mulmod_sm2_256(const mp_int* km, const ecc_point* gm, ecc_point* r,
     }
 
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (k != NULL)
-        XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    if (point != NULL)
-        XFREE(point, heap, DYNAMIC_TYPE_ECC);
+    XFREE(k, heap, DYNAMIC_TYPE_ECC);
+    XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -3397,10 +3394,8 @@ int sp_ecc_mulmod_add_sm2_256(const mp_int* km, const ecc_point* gm,
     }
 
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (k != NULL)
-        XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    if (point != NULL)
-        XFREE(point, heap, DYNAMIC_TYPE_ECC);
+    XFREE(k, heap, DYNAMIC_TYPE_ECC);
+    XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -4786,10 +4781,8 @@ int sp_ecc_mulmod_base_sm2_256(const mp_int* km, ecc_point* r, int map, void* he
     }
 
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (k != NULL)
-        XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    if (point != NULL)
-        XFREE(point, heap, DYNAMIC_TYPE_ECC);
+    XFREE(k, heap, DYNAMIC_TYPE_ECC);
+    XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -4864,10 +4857,8 @@ int sp_ecc_mulmod_base_add_sm2_256(const mp_int* km, const ecc_point* am,
     }
 
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (k != NULL)
-        XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    if (point)
-        XFREE(point, heap, DYNAMIC_TYPE_ECC);
+    XFREE(k, heap, DYNAMIC_TYPE_ECC);
+    XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -4931,6 +4922,7 @@ static void sp_256_from_bin(sp_digit* r, int size, const byte* a, int n)
  */
 static int sp_256_ecc_gen_k_sm2_5(WC_RNG* rng, sp_digit* k)
 {
+#ifndef WC_NO_RNG
     int err;
     byte buf[32];
 
@@ -4947,6 +4939,11 @@ static int sp_256_ecc_gen_k_sm2_5(WC_RNG* rng, sp_digit* k)
     while (err == 0);
 
     return err;
+#else
+    (void)rng;
+    (void)k;
+    return NOT_COMPILED_IN;
+#endif
 }
 
 /* Makes a random EC key pair.
@@ -5025,12 +5022,9 @@ int sp_ecc_make_key_sm2_256(WC_RNG* rng, mp_int* priv, ecc_point* pub, void* hea
     }
 
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (k != NULL)
-        XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    if (point != NULL) {
-        /* point is not sensitive, so no need to zeroize */
-        XFREE(point, heap, DYNAMIC_TYPE_ECC);
-    }
+    XFREE(k, heap, DYNAMIC_TYPE_ECC);
+    /* point is not sensitive, so no need to zeroize */
+    XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -5213,10 +5207,8 @@ int sp_ecc_secret_gen_sm2_256(const mp_int* priv, const ecc_point* pub, byte* ou
     }
 
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (k != NULL)
-        XFREE(k, heap, DYNAMIC_TYPE_ECC);
-    if (point != NULL)
-        XFREE(point, heap, DYNAMIC_TYPE_ECC);
+    XFREE(k, heap, DYNAMIC_TYPE_ECC);
+    XFREE(point, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -5738,9 +5730,6 @@ int sp_ecc_verify_sm2_256(const byte* hash, word32 hashLen, const mp_int* pX,
         /* (r - e + n*order).z'.z' mod prime == (s.G + t.Q)->x' */
         /* Load e, subtract from r. */
         sp_256_from_bin(e, 5, hash, (int)hashLen);
-        if (sp_256_cmp_sm2_5(r, e) < 0) {
-            carry = sp_256_add_sm2_5(r, r, p256_sm2_order);
-        }
         sp_256_sub_sm2_5(e, r, e);
         sp_256_norm_5(e);
         /* x' == (r - e).z'.z' mod prime */
@@ -5768,7 +5757,7 @@ int sp_ecc_verify_sm2_256(const byte* hash, word32 hashLen, const mp_int* pX,
 #endif /* HAVE_ECC_VERIFY */
 
 #ifdef HAVE_ECC_CHECK_KEY
-/* Check that the x and y oridinates are a valid point on the curve.
+/* Check that the x and y ordinates are a valid point on the curve.
  *
  * point  EC point.
  * heap   Heap to use if dynamically allocating.
@@ -5817,14 +5806,13 @@ static int sp_256_ecc_is_point_sm2_5(const sp_point_256* point,
     }
 
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (t1 != NULL)
-        XFREE(t1, heap, DYNAMIC_TYPE_ECC);
+    XFREE(t1, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
 }
 
-/* Check that the x and y oridinates are a valid point on the curve.
+/* Check that the x and y ordinates are a valid point on the curve.
  *
  * pX  X ordinate of EC point.
  * pY  Y ordinate of EC point.
@@ -5857,8 +5845,7 @@ int sp_ecc_is_point_sm2_256(const mp_int* pX, const mp_int* pY)
     }
 
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (pub != NULL)
-        XFREE(pub, NULL, DYNAMIC_TYPE_ECC);
+    XFREE(pub, NULL, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -5966,10 +5953,8 @@ int sp_ecc_check_key_sm2_256(const mp_int* pX, const mp_int* pY,
     }
 
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (pub != NULL)
-        XFREE(pub, heap, DYNAMIC_TYPE_ECC);
-    if (priv != NULL)
-        XFREE(priv, heap, DYNAMIC_TYPE_ECC);
+    XFREE(pub, heap, DYNAMIC_TYPE_ECC);
+    XFREE(priv, heap, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -6048,10 +6033,8 @@ int sp_ecc_proj_add_point_sm2_256(mp_int* pX, mp_int* pY, mp_int* pZ,
     }
 
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (tmp != NULL)
-        XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
-    if (p != NULL)
-        XFREE(p, NULL, DYNAMIC_TYPE_ECC);
+    XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
+    XFREE(p, NULL, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -6116,10 +6099,8 @@ int sp_ecc_proj_dbl_point_sm2_256(mp_int* pX, mp_int* pY, mp_int* pZ,
     }
 
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (tmp != NULL)
-        XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
-    if (p != NULL)
-        XFREE(p, NULL, DYNAMIC_TYPE_ECC);
+    XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
+    XFREE(p, NULL, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -6180,10 +6161,8 @@ int sp_ecc_map_sm2_256(mp_int* pX, mp_int* pY, mp_int* pZ)
     }
 
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (tmp != NULL)
-        XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
-    if (p != NULL)
-        XFREE(p, NULL, DYNAMIC_TYPE_ECC);
+    XFREE(tmp, NULL, DYNAMIC_TYPE_ECC);
+    XFREE(p, NULL, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;
@@ -6298,8 +6277,7 @@ int sp_ecc_uncompress_sm2_256(mp_int* xm, int odd, mp_int* ym)
     }
 
 #ifdef WOLFSSL_SP_SMALL_STACK
-    if (x != NULL)
-        XFREE(x, NULL, DYNAMIC_TYPE_ECC);
+    XFREE(x, NULL, DYNAMIC_TYPE_ECC);
 #endif
 
     return err;

--- a/sp_sm2_x86_64_asm.S
+++ b/sp_sm2_x86_64_asm.S
@@ -1,6 +1,6 @@
 /* sp_sm2_x86_64_asm.S */
 /*
- * Copyright (C) 2006-2023 wolfSSL Inc.
+ * Copyright (C) 2006-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *


### PR DESCRIPTION
remove frivolous computation of "carry" in `scripts/sp/ecc_sm2.rb`:`sp_ecc_verify_sm2()`; regenerate asm at scripts:550e22f72c by invoking `./gen-asm.sh`.

tested with
```
WOLFSM_HEAD=local:c0f6e4d49b2a5e45b84d21c4c74c6153b7501c08 ../testing/git-hooks/wolfssl-multi-test.sh --keep-going --max-check-try-count=2 --enable-bwrap --verbose-analyzers --enable-text-styles --report-cumulative-times --no-result-cache --no-git-refresh --test-uncommitted wolfsm-all-clang-tidy
```
