### PR TITLE
20240924-fix-20240913-clang-tidy

### DIFF
--- a/scripts/sp/ecc_sm2.rb
+++ b/scripts/sp/ecc_sm2.rb
@@ -580,6 +580,9 @@ EOF
         /* (r - e + n*order).z'.z' mod prime == (s.G + t.Q)->x' */
         /* Load e, subtract from r. */
         sp_#{@total}_from_bin(e, #{@words}, hash, (int)hashLen);
+        if (sp_#{@total}_cmp_#{@namef}#{@words}(r, e) < 0) {
+            (void)sp_#{@total}_add_#{@namef}#{@words}(r, r, #{@cname}_order);
+        }
         sp_#{@total}_sub_#{@namef}#{@words}(e, r, e);
         sp_#{@total}_norm_#{@words}(e);
         /* x' == (r - e).z'.z' mod prime */

--- a/sp_sm2_arm32.c
+++ b/sp_sm2_arm32.c
@@ -16772,6 +16772,9 @@ int sp_ecc_verify_sm2_256(const byte* hash, word32 hashLen, const mp_int* pX,
         /* (r - e + n*order).z'.z' mod prime == (s.G + t.Q)->x' */
         /* Load e, subtract from r. */
         sp_256_from_bin(e, 8, hash, (int)hashLen);
+        if (sp_256_cmp_sm2_8(r, e) < 0) {
+            (void)sp_256_add_sm2_8(r, r, p256_sm2_order);
+        }
         sp_256_sub_sm2_8(e, r, e);
         sp_256_norm_8(e);
         /* x' == (r - e).z'.z' mod prime */

--- a/sp_sm2_arm64.c
+++ b/sp_sm2_arm64.c
@@ -19729,6 +19729,9 @@ int sp_ecc_verify_sm2_256(const byte* hash, word32 hashLen, const mp_int* pX,
         /* (r - e + n*order).z'.z' mod prime == (s.G + t.Q)->x' */
         /* Load e, subtract from r. */
         sp_256_from_bin(e, 4, hash, (int)hashLen);
+        if (sp_256_cmp_sm2_4(r, e) < 0) {
+            (void)sp_256_add_sm2_4(r, r, p256_sm2_order);
+        }
         sp_256_sub_sm2_4(e, r, e);
         sp_256_norm_4(e);
         /* x' == (r - e).z'.z' mod prime */

--- a/sp_sm2_armthumb.c
+++ b/sp_sm2_armthumb.c
@@ -9451,6 +9451,9 @@ int sp_ecc_verify_sm2_256(const byte* hash, word32 hashLen, const mp_int* pX,
         /* (r - e + n*order).z'.z' mod prime == (s.G + t.Q)->x' */
         /* Load e, subtract from r. */
         sp_256_from_bin(e, 8, hash, (int)hashLen);
+        if (sp_256_cmp_sm2_8(r, e) < 0) {
+            (void)sp_256_add_sm2_8(r, r, p256_sm2_order);
+        }
         sp_256_sub_sm2_8(e, r, e);
         sp_256_norm_8(e);
         /* x' == (r - e).z'.z' mod prime */

--- a/sp_sm2_c32.c
+++ b/sp_sm2_c32.c
@@ -5976,6 +5976,9 @@ int sp_ecc_verify_sm2_256(const byte* hash, word32 hashLen, const mp_int* pX,
         /* (r - e + n*order).z'.z' mod prime == (s.G + t.Q)->x' */
         /* Load e, subtract from r. */
         sp_256_from_bin(e, 9, hash, (int)hashLen);
+        if (sp_256_cmp_sm2_9(r, e) < 0) {
+            (void)sp_256_add_sm2_9(r, r, p256_sm2_order);
+        }
         sp_256_sub_sm2_9(e, r, e);
         sp_256_norm_9(e);
         /* x' == (r - e).z'.z' mod prime */

--- a/sp_sm2_c64.c
+++ b/sp_sm2_c64.c
@@ -5730,6 +5730,9 @@ int sp_ecc_verify_sm2_256(const byte* hash, word32 hashLen, const mp_int* pX,
         /* (r - e + n*order).z'.z' mod prime == (s.G + t.Q)->x' */
         /* Load e, subtract from r. */
         sp_256_from_bin(e, 5, hash, (int)hashLen);
+        if (sp_256_cmp_sm2_5(r, e) < 0) {
+            (void)sp_256_add_sm2_5(r, r, p256_sm2_order);
+        }
         sp_256_sub_sm2_5(e, r, e);
         sp_256_norm_5(e);
         /* x' == (r - e).z'.z' mod prime */

--- a/sp_sm2_cortexm.c
+++ b/sp_sm2_cortexm.c
@@ -9510,6 +9510,9 @@ int sp_ecc_verify_sm2_256(const byte* hash, word32 hashLen, const mp_int* pX,
         /* (r - e + n*order).z'.z' mod prime == (s.G + t.Q)->x' */
         /* Load e, subtract from r. */
         sp_256_from_bin(e, 8, hash, (int)hashLen);
+        if (sp_256_cmp_sm2_8(r, e) < 0) {
+            (void)sp_256_add_sm2_8(r, r, p256_sm2_order);
+        }
         sp_256_sub_sm2_8(e, r, e);
         sp_256_norm_8(e);
         /* x' == (r - e).z'.z' mod prime */

--- a/sp_sm2_x86_64.c
+++ b/sp_sm2_x86_64.c
@@ -17813,6 +17813,9 @@ int sp_ecc_verify_sm2_256(const byte* hash, word32 hashLen, const mp_int* pX,
         /* (r - e + n*order).z'.z' mod prime == (s.G + t.Q)->x' */
         /* Load e, subtract from r. */
         sp_256_from_bin(e, 4, hash, (int)hashLen);
+        if (sp_256_cmp_sm2_4(r, e) < 0) {
+            (void)sp_256_add_sm2_4(r, r, p256_sm2_order);
+        }
         sp_256_sub_sm2_4(e, r, e);
         sp_256_norm_4(e);
         /* x' == (r - e).z'.z' mod prime */


### PR DESCRIPTION
`scripts/sp/ecc_sm2.rb`: restore code removed by c0f6e4d49b, except omit the frivolous assignment of `carry`.

tested with `wolfssl-multi-test.sh ... wolfsm-all-gcc-latest wolfsm-all-clang-tidy wolfsm-all-cppcheck`
