### PR TITLE
20250225-sm3-just-use-ByteReverseWords

### DIFF
--- a/sm3.c
+++ b/sm3.c
@@ -174,52 +174,6 @@ static void sm3_set_compress_x64(void)
  * Also around prototypes.
  */
 
-#if !defined(WOLFSSL_SM3_SMALL) && !defined(HAVE_INTEL_AVX1)
-
-/* Reverse block size worth of 32-bit words.
- *
- * @param [out] out  Output buffer to write to.
- * @param [in]  in   Buffer to reverse.
- */
-#define BSWAP32_16(out, in)                                         \
-    do {                                                            \
-        ((word32*)out)[ 0] = ByteReverseWord32(((word32*)in)[ 0]);  \
-        ((word32*)out)[ 1] = ByteReverseWord32(((word32*)in)[ 1]);  \
-        ((word32*)out)[ 2] = ByteReverseWord32(((word32*)in)[ 2]);  \
-        ((word32*)out)[ 3] = ByteReverseWord32(((word32*)in)[ 3]);  \
-        ((word32*)out)[ 4] = ByteReverseWord32(((word32*)in)[ 4]);  \
-        ((word32*)out)[ 5] = ByteReverseWord32(((word32*)in)[ 5]);  \
-        ((word32*)out)[ 6] = ByteReverseWord32(((word32*)in)[ 6]);  \
-        ((word32*)out)[ 7] = ByteReverseWord32(((word32*)in)[ 7]);  \
-        ((word32*)out)[ 8] = ByteReverseWord32(((word32*)in)[ 8]);  \
-        ((word32*)out)[ 9] = ByteReverseWord32(((word32*)in)[ 9]);  \
-        ((word32*)out)[10] = ByteReverseWord32(((word32*)in)[10]);  \
-        ((word32*)out)[11] = ByteReverseWord32(((word32*)in)[11]);  \
-        ((word32*)out)[12] = ByteReverseWord32(((word32*)in)[12]);  \
-        ((word32*)out)[13] = ByteReverseWord32(((word32*)in)[13]);  \
-        ((word32*)out)[14] = ByteReverseWord32(((word32*)in)[14]);  \
-        ((word32*)out)[15] = ByteReverseWord32(((word32*)in)[15]);  \
-    } while (0)
-
-/* Reverse digest size worth of 32-bit words.
- *
- * @param [out] out  Output buffer to write to.
- * @param [in]  in   Buffer to reverse.
- */
-#define BSWAP32_8(out, in)                                          \
-    do {                                                            \
-        ((word32*)out)[ 0] = ByteReverseWord32(((word32*)in)[ 0]);  \
-        ((word32*)out)[ 1] = ByteReverseWord32(((word32*)in)[ 1]);  \
-        ((word32*)out)[ 2] = ByteReverseWord32(((word32*)in)[ 2]);  \
-        ((word32*)out)[ 3] = ByteReverseWord32(((word32*)in)[ 3]);  \
-        ((word32*)out)[ 4] = ByteReverseWord32(((word32*)in)[ 4]);  \
-        ((word32*)out)[ 5] = ByteReverseWord32(((word32*)in)[ 5]);  \
-        ((word32*)out)[ 6] = ByteReverseWord32(((word32*)in)[ 6]);  \
-        ((word32*)out)[ 7] = ByteReverseWord32(((word32*)in)[ 7]);  \
-    } while (0)
-
-#else
-
 /* Reverse block size worth of 32-bit words.
  *
  * @param [out] out  Output buffer to write to.
@@ -235,34 +189,6 @@ static void sm3_set_compress_x64(void)
  */
 #define BSWAP32_8(out, in) \
     ByteReverseWords((word32*)(out), (const word32*)(in), WC_SM3_DIGEST_SIZE)
-
-#endif
-
-#if defined(__aarch64__) || defined(__arm__)
-/* Reverse block size worth of 32-bit words.
- *
- * @param [out] out  Output buffer to write to.
- * @param [in]  in   Buffer to reverse. May be unaligned.
- */
-#define BSWAP32_16_UNALIGNED(out, in)       \
-    do {                                    \
-        word32 t[16];                       \
-        word32* tp = (word32*)in;           \
-        if (((wc_ptr_t)in & 0x3) != 0) {    \
-            XMEMCPY(t, in, sizeof(t));      \
-            tp = t;                         \
-        }                                   \
-        BSWAP32_16(out, tp);                \
-    } while (0)
-#else
-/* Reverse block size worth of 32-bit words.
- *
- * @param [out] out  Output buffer to write to.
- * @param [in]  in   Buffer to reverse. May be unaligned.
- */
-#define BSWAP32_16_UNALIGNED(out, in)   \
-    BSWAP32_16(out, in)
-#endif
 
 #if !(defined(WOLFSSL_X86_64_BUILD) || defined(WOLFSSL_X86_BUILD))
 /* Permutation function within the compression function.
@@ -849,7 +775,7 @@ static void sm3_compress_len_c(wc_Sm3* sm3, const byte* data, word32 len)
 #ifdef LITTLE_ENDIAN_ORDER
         word32* buffer = sm3->buffer;
         /* Convert big-endian bytes to little-endian 32-bit words. */
-        BSWAP32_16_UNALIGNED(buffer, data);
+        BSWAP32_16(buffer, data);
         /* Process block of data. */
         SM3_COMPRESS(sm3, buffer);
 #else


### PR DESCRIPTION
`sm3.c`: for `BSWAP32_16` and `BSWAP32_8`, just use the implementations based on `ByteReverseWords()`, to avoid unaligned access exposed by .https://github.com/wolfSSL/wolfssl/commit/6016cc0c974c2761617673fb920553d0467f6d1f.

Fixes numerous instances of
```
wolfcrypt/src/sm3.c:1156:9: runtime error: store to misaligned address 0x7fd4c3c1a8c1 for type 'word32', which requires 4 byte alignment
```
reported by `quantum-safe-wolfssl-wolfsm-all-cross-aarch64-armasm-unittest-sanitizer`.

Tested with `wolfssl-multi-test.sh ... wolfsm-all-gcc-latest quantum-safe-wolfssl-wolfsm-all-cross-aarch64-armasm-unittest-sanitizer`
