### PR TITLE
20250411-regen-and-libwolfssl_sources_h

### DIFF
--- a/sm2.c
+++ b/sm2.c
@@ -23,17 +23,12 @@
  *   https://datatracker.ietf.org/doc/html/draft-shen-sm2-ecdsa-02
  */
 
-#ifdef HAVE_CONFIG_H
-    #include <config.h>
-#endif
-
-#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 
 #if defined(WOLFSSL_SM2) && defined(HAVE_ECC)
 
 #include <wolfssl/wolfcrypt/sm2.h>
 #include <wolfssl/wolfcrypt/sp.h>
-#include <wolfssl/wolfcrypt/error-crypt.h>
 #include <wolfssl/wolfcrypt/hash.h>
 #include <wolfssl/wolfcrypt/coding.h>
 #include <wolfssl/wolfcrypt/asn.h>

--- a/sm3.c
+++ b/sm3.c
@@ -23,17 +23,11 @@
  *   https://datatracker.ietf.org/doc/html/draft-oscca-cfrg-sm3-02
  */
 
-#ifdef HAVE_CONFIG_H
-    #include <config.h>
-#endif
-
-#include <wolfssl/wolfcrypt/settings.h>
-#include <wolfssl/wolfcrypt/types.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 
 #ifdef WOLFSSL_SM3
 
 #include <wolfssl/wolfcrypt/sm3.h>
-#include <wolfssl/wolfcrypt/error-crypt.h>
 #include <wolfssl/wolfcrypt/cpuid.h>
 #include <wolfssl/wolfcrypt/hash.h>
 

--- a/sm3_asm.S
+++ b/sm3_asm.S
@@ -1,6 +1,6 @@
 /* sm3_asm.S */
 /*
- * Copyright (C) 2006-2024 wolfSSL Inc.
+ * Copyright (C) 2006-2025 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *
@@ -42,7 +42,9 @@
 #define HAVE_INTEL_AVX1
 #endif /* HAVE_INTEL_AVX1 */
 #ifndef NO_AVX2_SUPPORT
+#ifndef HAVE_INTEL_AVX2
 #define HAVE_INTEL_AVX2
+#endif /* HAVE_INTEL_AVX2 */
 #endif /* NO_AVX2_SUPPORT */
 
 #ifdef WOLFSSL_SM3

--- a/sm3_asm.asm
+++ b/sm3_asm.asm
@@ -1,6 +1,6 @@
 ; /* sm3_asm.asm */
 ; /*
-;  * Copyright (C) 2006-2024 wolfSSL Inc.
+;  * Copyright (C) 2006-2025 wolfSSL Inc.
 ;  *
 ;  * This file is part of wolfSSL.
 ;  *

--- a/sm4.c
+++ b/sm4.c
@@ -23,12 +23,7 @@
  *  https://datatracker.ietf.org/doc/html/draft-ribose-cfrg-sm4
  */
 
-#ifdef HAVE_CONFIG_H
-    #include <config.h>
-#endif
-
-#include <wolfssl/wolfcrypt/settings.h>
-#include <wolfssl/wolfcrypt/error-crypt.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 
 #ifdef WOLFSSL_SM4
 

--- a/sp_sm2_arm32.c
+++ b/sp_sm2_arm32.c
@@ -1,6 +1,6 @@
 /* sp.c
  *
- * Copyright (C) 2006-2024 wolfSSL Inc.
+ * Copyright (C) 2006-2025 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *
@@ -21,16 +21,11 @@
 
 /* Implementation by Sean Parkinson. */
 
-#ifdef HAVE_CONFIG_H
-    #include <config.h>
-#endif
-
-#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 
 #if defined(WOLFSSL_HAVE_SP_RSA) || defined(WOLFSSL_HAVE_SP_DH) || \
     defined(WOLFSSL_HAVE_SP_ECC)
 
-#include <wolfssl/wolfcrypt/error-crypt.h>
 #include <wolfssl/wolfcrypt/cpuid.h>
 #ifdef NO_INLINE
     #include <wolfssl/wolfcrypt/misc.h>
@@ -169,11 +164,17 @@ static const sp_digit p256_sm2_b[8] = {
  * a  A single precision integer.
  * b  A single precision integer.
  */
-static void sp_256_mul_sm2_8(sp_digit* r_p, const sp_digit* a_p, const sp_digit* b_p)
+static #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+void sp_256_mul_sm2_8(sp_digit* r_p, const sp_digit* a_p, const sp_digit* b_p)
+#else
+void sp_256_mul_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit* b)
+#endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     register sp_digit* r asm ("r0") = (sp_digit*)r_p;
     register const sp_digit* a asm ("r1") = (const sp_digit*)a_p;
     register const sp_digit* b asm ("r2") = (const sp_digit*)b_p;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 
     __asm__ __volatile__ (
         "sub	sp, sp, #0x40\n\t"
@@ -356,8 +357,13 @@ static void sp_256_mul_sm2_8(sp_digit* r_p, const sp_digit* a_p, const sp_digit*
         "stm	%[r]!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "subs	r5, r5, #32\n\t"
         "bgt	L_sp_256_mul_sm2_8_store_%=\n\t"
-        : [r] "+r" (r),  [a] "+r" (a),  [b] "+r" (b)
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+        : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
         :
+#else
+        :
+        : [r] "r" (r), [a] "r" (a), [b] "r" (b)
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
         : "memory", "cc", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "lr",
             "r11"
     );
@@ -371,11 +377,17 @@ static void sp_256_mul_sm2_8(sp_digit* r_p, const sp_digit* a_p, const sp_digit*
  * a  A single precision integer.
  * b  A single precision integer.
  */
-static void sp_256_mul_sm2_8(sp_digit* r_p, const sp_digit* a_p, const sp_digit* b_p)
+static #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+void sp_256_mul_sm2_8(sp_digit* r_p, const sp_digit* a_p, const sp_digit* b_p)
+#else
+void sp_256_mul_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit* b)
+#endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     register sp_digit* r asm ("r0") = (sp_digit*)r_p;
     register const sp_digit* a asm ("r1") = (const sp_digit*)a_p;
     register const sp_digit* b asm ("r2") = (const sp_digit*)b_p;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 
     __asm__ __volatile__ (
         "sub	sp, sp, #32\n\t"
@@ -2353,8 +2365,13 @@ static void sp_256_mul_sm2_8(sp_digit* r_p, const sp_digit* a_p, const sp_digit*
         "stm	%[r]!, {r3, r4, r5, r6}\n\t"
         "ldm	sp!, {r3, r4, r5, r6}\n\t"
         "stm	%[r]!, {r3, r4, r5, r6}\n\t"
-        : [r] "+r" (r),  [a] "+r" (a),  [b] "+r" (b)
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+        : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
         :
+#else
+        :
+        : [r] "r" (r), [a] "r" (a), [b] "r" (b)
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
         : "memory", "cc", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r11",
             "r12"
     );
@@ -2367,11 +2384,17 @@ static void sp_256_mul_sm2_8(sp_digit* r_p, const sp_digit* a_p, const sp_digit*
  * a  A single precision integer.
  * b  A single precision integer.
  */
-static void sp_256_mul_sm2_8(sp_digit* r_p, const sp_digit* a_p, const sp_digit* b_p)
+static #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+void sp_256_mul_sm2_8(sp_digit* r_p, const sp_digit* a_p, const sp_digit* b_p)
+#else
+void sp_256_mul_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit* b)
+#endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     register sp_digit* r asm ("r0") = (sp_digit*)r_p;
     register const sp_digit* a asm ("r1") = (const sp_digit*)a_p;
     register const sp_digit* b asm ("r2") = (const sp_digit*)b_p;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 
     __asm__ __volatile__ (
         "sub	sp, sp, #36\n\t"
@@ -2707,8 +2730,13 @@ static void sp_256_mul_sm2_8(sp_digit* r_p, const sp_digit* a_p, const sp_digit*
         "sub	%[r], %[r], #32\n\t"
         "stm	%[r], {r3, r4, r5, r6, r7, r8, r9, r10}\n\t"
         "add	sp, sp, #36\n\t"
-        : [r] "+r" (r),  [a] "+r" (a),  [b] "+r" (b)
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+        : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
         :
+#else
+        :
+        : [r] "r" (r), [a] "r" (a), [b] "r" (b)
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
         : "memory", "cc", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10",
             "r11", "r12", "lr"
     );
@@ -2721,11 +2749,17 @@ static void sp_256_mul_sm2_8(sp_digit* r_p, const sp_digit* a_p, const sp_digit*
  * a  A single precision integer.
  * b  A single precision integer.
  */
-static void sp_256_mul_sm2_8(sp_digit* r_p, const sp_digit* a_p, const sp_digit* b_p)
+static #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+void sp_256_mul_sm2_8(sp_digit* r_p, const sp_digit* a_p, const sp_digit* b_p)
+#else
+void sp_256_mul_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit* b)
+#endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     register sp_digit* r asm ("r0") = (sp_digit*)r_p;
     register const sp_digit* a asm ("r1") = (const sp_digit*)a_p;
     register const sp_digit* b asm ("r2") = (const sp_digit*)b_p;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 
     __asm__ __volatile__ (
         "sub	sp, sp, #44\n\t"
@@ -2839,8 +2873,13 @@ static void sp_256_mul_sm2_8(sp_digit* r_p, const sp_digit* a_p, const sp_digit*
         "ldm	sp, {r3, r4, r5, r6, r7, r8, r9, r10}\n\t"
         "stm	lr, {r3, r4, r5, r6, r7, r8, r9, r10}\n\t"
         "add	sp, sp, #44\n\t"
-        : [r] "+r" (r),  [a] "+r" (a),  [b] "+r" (b)
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+        : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
         :
+#else
+        :
+        : [r] "r" (r), [a] "r" (a), [b] "r" (b)
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
         : "memory", "cc", "r3", "r4", "r5", "r6", "r10", "r11", "r12", "r7",
             "r8", "r9", "lr"
     );
@@ -2854,10 +2893,16 @@ static void sp_256_mul_sm2_8(sp_digit* r_p, const sp_digit* a_p, const sp_digit*
  * r  A single precision integer.
  * a  A single precision integer.
  */
-static void sp_256_sqr_sm2_8(sp_digit* r_p, const sp_digit* a_p)
+static #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+void sp_256_sqr_sm2_8(sp_digit* r_p, const sp_digit* a_p)
+#else
+void sp_256_sqr_sm2_8(sp_digit* r, const sp_digit* a)
+#endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     register sp_digit* r asm ("r0") = (sp_digit*)r_p;
     register const sp_digit* a asm ("r1") = (const sp_digit*)a_p;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 
     __asm__ __volatile__ (
         "sub	sp, sp, #0x40\n\t"
@@ -3000,8 +3045,13 @@ static void sp_256_sqr_sm2_8(sp_digit* r_p, const sp_digit* a_p)
         "stm	%[r]!, {r3, r4, r6, r7, r8, r9, r10, r11}\n\t"
         "subs	r5, r5, #32\n\t"
         "bgt	L_sp_256_sqr_sm2_8_store_%=\n\t"
-        : [r] "+r" (r),  [a] "+r" (a)
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+        : [r] "+r" (r), [a] "+r" (a)
         :
+#else
+        :
+        : [r] "r" (r), [a] "r" (a)
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
         : "memory", "cc", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "lr",
             "r11"
     );
@@ -3014,10 +3064,16 @@ static void sp_256_sqr_sm2_8(sp_digit* r_p, const sp_digit* a_p)
  * r  A single precision integer.
  * a  A single precision integer.
  */
-static void sp_256_sqr_sm2_8(sp_digit* r_p, const sp_digit* a_p)
+static #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+void sp_256_sqr_sm2_8(sp_digit* r_p, const sp_digit* a_p)
+#else
+void sp_256_sqr_sm2_8(sp_digit* r, const sp_digit* a)
+#endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     register sp_digit* r asm ("r0") = (sp_digit*)r_p;
     register const sp_digit* a asm ("r1") = (const sp_digit*)a_p;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 
     __asm__ __volatile__ (
         "sub	sp, sp, #32\n\t"
@@ -4212,8 +4268,13 @@ static void sp_256_sqr_sm2_8(sp_digit* r_p, const sp_digit* a_p)
         "stm	%[r]!, {r2, r3, r4, r8}\n\t"
         "ldm	sp!, {r2, r3, r4, r8}\n\t"
         "stm	%[r]!, {r2, r3, r4, r8}\n\t"
-        : [r] "+r" (r),  [a] "+r" (a)
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+        : [r] "+r" (r), [a] "+r" (a)
         :
+#else
+        :
+        : [r] "r" (r), [a] "r" (a)
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
         : "memory", "cc", "r2", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10",
             "r12"
     );
@@ -4225,10 +4286,16 @@ static void sp_256_sqr_sm2_8(sp_digit* r_p, const sp_digit* a_p)
  * r  A single precision integer.
  * a  A single precision integer.
  */
-static void sp_256_sqr_sm2_8(sp_digit* r_p, const sp_digit* a_p)
+static #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+void sp_256_sqr_sm2_8(sp_digit* r_p, const sp_digit* a_p)
+#else
+void sp_256_sqr_sm2_8(sp_digit* r, const sp_digit* a)
+#endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     register sp_digit* r asm ("r0") = (sp_digit*)r_p;
     register const sp_digit* a asm ("r1") = (const sp_digit*)a_p;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 
     __asm__ __volatile__ (
         "sub	sp, sp, #0x44\n\t"
@@ -4456,8 +4523,13 @@ static void sp_256_sqr_sm2_8(sp_digit* r_p, const sp_digit* a_p)
         "sub	%[r], %[r], #32\n\t"
         "stm	%[r], {r3, r4, r5, r6, r7, r8, r9, r10}\n\t"
         "add	sp, sp, #0x44\n\t"
-        : [r] "+r" (r),  [a] "+r" (a)
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+        : [r] "+r" (r), [a] "+r" (a)
         :
+#else
+        :
+        : [r] "r" (r), [a] "r" (a)
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
         : "memory", "cc", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10",
             "r11", "r12", "lr"
     );
@@ -4469,10 +4541,16 @@ static void sp_256_sqr_sm2_8(sp_digit* r_p, const sp_digit* a_p)
  * r  A single precision integer.
  * a  A single precision integer.
  */
-static void sp_256_sqr_sm2_8(sp_digit* r_p, const sp_digit* a_p)
+static #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+void sp_256_sqr_sm2_8(sp_digit* r_p, const sp_digit* a_p)
+#else
+void sp_256_sqr_sm2_8(sp_digit* r, const sp_digit* a)
+#endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     register sp_digit* r asm ("r0") = (sp_digit*)r_p;
     register const sp_digit* a asm ("r1") = (const sp_digit*)a_p;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 
     __asm__ __volatile__ (
         "sub	sp, sp, #32\n\t"
@@ -4573,8 +4651,13 @@ static void sp_256_sqr_sm2_8(sp_digit* r_p, const sp_digit* a_p)
         "ldm	sp, {r0, r1, r2, r3, r4, r5, r6}\n\t"
         "stm	lr, {r0, r1, r2, r3, r4, r5, r6}\n\t"
         "add	sp, sp, #32\n\t"
-        : [r] "+r" (r),  [a] "+r" (a)
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+        : [r] "+r" (r), [a] "+r" (a)
         :
+#else
+        :
+        : [r] "r" (r), [a] "r" (a)
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
         : "memory", "cc", "r2", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10",
             "r11", "r12", "lr"
     );
@@ -4589,12 +4672,18 @@ static void sp_256_sqr_sm2_8(sp_digit* r_p, const sp_digit* a_p)
  * a  A single precision integer.
  * b  A single precision integer.
  */
-static sp_digit sp_256_add_sm2_8(sp_digit* r_p, const sp_digit* a_p,
+static #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+sp_digit sp_256_add_sm2_8(sp_digit* r_p, const sp_digit* a_p,
     const sp_digit* b_p)
+#else
+sp_digit sp_256_add_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit* b)
+#endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     register sp_digit* r asm ("r0") = (sp_digit*)r_p;
     register const sp_digit* a asm ("r1") = (const sp_digit*)a_p;
     register const sp_digit* b asm ("r2") = (const sp_digit*)b_p;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 
     __asm__ __volatile__ (
         "mov	r3, #0\n\t"
@@ -4614,12 +4703,17 @@ static sp_digit sp_256_add_sm2_8(sp_digit* r_p, const sp_digit* a_p,
         "cmp	%[a], r12\n\t"
         "bne	L_sp_256_add_sm2_8_word_%=\n\t"
         "mov	%[r], r3\n\t"
-        : [r] "+r" (r),  [a] "+r" (a),  [b] "+r" (b)
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+        : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
         :
+#else
+        :
+        : [r] "r" (r), [a] "r" (a), [b] "r" (b)
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
         : "memory", "cc", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11",
             "r3", "r12"
     );
-    return (uint32_t)(size_t)r;
+    return (word32)(size_t)r;
 }
 
 #else
@@ -4629,12 +4723,18 @@ static sp_digit sp_256_add_sm2_8(sp_digit* r_p, const sp_digit* a_p,
  * a  A single precision integer.
  * b  A single precision integer.
  */
-static sp_digit sp_256_add_sm2_8(sp_digit* r_p, const sp_digit* a_p,
+static #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+sp_digit sp_256_add_sm2_8(sp_digit* r_p, const sp_digit* a_p,
     const sp_digit* b_p)
+#else
+sp_digit sp_256_add_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit* b)
+#endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     register sp_digit* r asm ("r0") = (sp_digit*)r_p;
     register const sp_digit* a asm ("r1") = (const sp_digit*)a_p;
     register const sp_digit* b asm ("r2") = (const sp_digit*)b_p;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 
     __asm__ __volatile__ (
         "ldm	%[a]!, {r3, r4, r5, r6}\n\t"
@@ -4653,11 +4753,16 @@ static sp_digit sp_256_add_sm2_8(sp_digit* r_p, const sp_digit* a_p,
         "stm	%[r]!, {r3, r4, r5, r6}\n\t"
         "mov	%[r], #0\n\t"
         "adc	%[r], %[r], #0\n\t"
-        : [r] "+r" (r),  [a] "+r" (a),  [b] "+r" (b)
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+        : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
         :
+#else
+        :
+        : [r] "r" (r), [a] "r" (a), [b] "r" (b)
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
         : "memory", "cc", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10"
     );
-    return (uint32_t)(size_t)r;
+    return (word32)(size_t)r;
 }
 
 #endif /* WOLFSSL_SP_SMALL */
@@ -4667,10 +4772,16 @@ static sp_digit sp_256_add_sm2_8(sp_digit* r_p, const sp_digit* a_p,
  * a  A single precision integer.
  * b  A single precision integer.
  */
-static sp_digit sp_256_sub_in_place_sm2_8(sp_digit* a_p, const sp_digit* b_p)
+static #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+sp_digit sp_256_sub_in_place_sm2_8(sp_digit* a_p, const sp_digit* b_p)
+#else
+sp_digit sp_256_sub_in_place_sm2_8(sp_digit* a, const sp_digit* b)
+#endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     register sp_digit* a asm ("r0") = (sp_digit*)a_p;
     register const sp_digit* b asm ("r1") = (const sp_digit*)b_p;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 
     __asm__ __volatile__ (
         "mov	r12, #0\n\t"
@@ -4689,12 +4800,17 @@ static sp_digit sp_256_sub_in_place_sm2_8(sp_digit* a_p, const sp_digit* b_p)
         "cmp	%[a], lr\n\t"
         "bne	L_sp_256_sub_in_pkace_sm2_8_word_%=\n\t"
         "mov	%[a], r12\n\t"
-        : [a] "+r" (a),  [b] "+r" (b)
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+        : [a] "+r" (a), [b] "+r" (b)
         :
+#else
+        :
+        : [a] "r" (a), [b] "r" (b)
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
         : "memory", "cc", "r2", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r12",
             "lr"
     );
-    return (uint32_t)(size_t)a;
+    return (word32)(size_t)a;
 }
 
 #else
@@ -4703,10 +4819,16 @@ static sp_digit sp_256_sub_in_place_sm2_8(sp_digit* a_p, const sp_digit* b_p)
  * a  A single precision integer and result.
  * b  A single precision integer.
  */
-static sp_digit sp_256_sub_in_place_sm2_8(sp_digit* a_p, const sp_digit* b_p)
+static #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+sp_digit sp_256_sub_in_place_sm2_8(sp_digit* a_p, const sp_digit* b_p)
+#else
+sp_digit sp_256_sub_in_place_sm2_8(sp_digit* a, const sp_digit* b)
+#endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     register sp_digit* a asm ("r0") = (sp_digit*)a_p;
     register const sp_digit* b asm ("r1") = (const sp_digit*)b_p;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 
     __asm__ __volatile__ (
         "ldm	%[a], {r2, r3, r4, r5}\n\t"
@@ -4724,11 +4846,16 @@ static sp_digit sp_256_sub_in_place_sm2_8(sp_digit* a_p, const sp_digit* b_p)
         "sbcs	r5, r5, r9\n\t"
         "stm	%[a]!, {r2, r3, r4, r5}\n\t"
         "sbc	%[a], r9, r9\n\t"
-        : [a] "+r" (a),  [b] "+r" (b)
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+        : [a] "+r" (a), [b] "+r" (b)
         :
+#else
+        :
+        : [a] "r" (a), [b] "r" (b)
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
         : "memory", "cc", "r2", "r3", "r4", "r5", "r6", "r7", "r8", "r9"
     );
-    return (uint32_t)(size_t)a;
+    return (word32)(size_t)a;
 }
 
 #endif /* WOLFSSL_SP_SMALL */
@@ -4741,13 +4868,20 @@ static sp_digit sp_256_sub_in_place_sm2_8(sp_digit* a_p, const sp_digit* b_p)
  * b  A single precision number to subtract.
  * m  Mask value to apply.
  */
-static sp_digit sp_256_cond_sub_sm2_8(sp_digit* r_p, const sp_digit* a_p,
+static #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+sp_digit sp_256_cond_sub_sm2_8(sp_digit* r_p, const sp_digit* a_p,
     const sp_digit* b_p, sp_digit m_p)
+#else
+sp_digit sp_256_cond_sub_sm2_8(sp_digit* r, const sp_digit* a,
+    const sp_digit* b, sp_digit m)
+#endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     register sp_digit* r asm ("r0") = (sp_digit*)r_p;
     register const sp_digit* a asm ("r1") = (const sp_digit*)a_p;
     register const sp_digit* b asm ("r2") = (const sp_digit*)b_p;
     register sp_digit m asm ("r3") = (sp_digit)m_p;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 
     __asm__ __volatile__ (
         "mov	r6, #0\n\t"
@@ -4766,11 +4900,16 @@ static sp_digit sp_256_cond_sub_sm2_8(sp_digit* r_p, const sp_digit* a_p,
         "cmp	lr, #32\n\t"
         "blt	L_sp_256_cond_sub_sm2_8_words_%=\n\t"
         "mov	%[r], r12\n\t"
-        : [r] "+r" (r),  [a] "+r" (a),  [b] "+r" (b),  [m] "+r" (m)
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+        : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b), [m] "+r" (m)
         :
+#else
+        :
+        : [r] "r" (r), [a] "r" (a), [b] "r" (b), [m] "r" (m)
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
         : "memory", "cc", "r12", "lr", "r4", "r5", "r6"
     );
-    return (uint32_t)(size_t)r;
+    return (word32)(size_t)r;
 }
 
 #else
@@ -4782,13 +4921,20 @@ static sp_digit sp_256_cond_sub_sm2_8(sp_digit* r_p, const sp_digit* a_p,
  * b  A single precision number to subtract.
  * m  Mask value to apply.
  */
-static sp_digit sp_256_cond_sub_sm2_8(sp_digit* r_p, const sp_digit* a_p,
+static #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+sp_digit sp_256_cond_sub_sm2_8(sp_digit* r_p, const sp_digit* a_p,
     const sp_digit* b_p, sp_digit m_p)
+#else
+sp_digit sp_256_cond_sub_sm2_8(sp_digit* r, const sp_digit* a,
+    const sp_digit* b, sp_digit m)
+#endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     register sp_digit* r asm ("r0") = (sp_digit*)r_p;
     register const sp_digit* a asm ("r1") = (const sp_digit*)a_p;
     register const sp_digit* b asm ("r2") = (const sp_digit*)b_p;
     register sp_digit m asm ("r3") = (sp_digit)m_p;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 
     __asm__ __volatile__ (
         "mov	lr, #0\n\t"
@@ -4821,11 +4967,16 @@ static sp_digit sp_256_cond_sub_sm2_8(sp_digit* r_p, const sp_digit* a_p,
         "sbcs	r5, r5, r7\n\t"
         "stm	%[r]!, {r4, r5}\n\t"
         "sbc	%[r], lr, lr\n\t"
-        : [r] "+r" (r),  [a] "+r" (a),  [b] "+r" (b),  [m] "+r" (m)
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+        : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b), [m] "+r" (m)
         :
+#else
+        :
+        : [r] "r" (r), [a] "r" (a), [b] "r" (b), [m] "r" (m)
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
         : "memory", "cc", "r12", "lr", "r4", "r5", "r6", "r7"
     );
-    return (uint32_t)(size_t)r;
+    return (word32)(size_t)r;
 }
 
 #endif /* WOLFSSL_SP_SMALL */
@@ -4836,11 +4987,17 @@ static sp_digit sp_256_cond_sub_sm2_8(sp_digit* r_p, const sp_digit* a_p,
  * a  A single precision integer.
  * b  A single precision digit.
  */
-static void sp_256_mul_d_sm2_8(sp_digit* r_p, const sp_digit* a_p, sp_digit b_p)
+static #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+void sp_256_mul_d_sm2_8(sp_digit* r_p, const sp_digit* a_p, sp_digit b_p)
+#else
+void sp_256_mul_d_sm2_8(sp_digit* r, const sp_digit* a, sp_digit b)
+#endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     register sp_digit* r asm ("r0") = (sp_digit*)r_p;
     register const sp_digit* a asm ("r1") = (const sp_digit*)a_p;
     register sp_digit b asm ("r2") = (sp_digit)b_p;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 
     __asm__ __volatile__ (
         /* A[0] * B */
@@ -4921,8 +5078,13 @@ static void sp_256_mul_d_sm2_8(sp_digit* r_p, const sp_digit* a_p, sp_digit b_p)
         "cmp	r9, #32\n\t"
         "blt	L_sp_256_mul_d_sm2_8_word_%=\n\t"
         "str	r3, [%[r], #32]\n\t"
-        : [r] "+r" (r),  [a] "+r" (a),  [b] "+r" (b)
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+        : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
         :
+#else
+        :
+        : [r] "r" (r), [a] "r" (a), [b] "r" (b)
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
         : "memory", "cc", "r3", "r4", "r5", "r6", "r7", "r8", "r9"
     );
 }
@@ -4934,11 +5096,17 @@ static void sp_256_mul_d_sm2_8(sp_digit* r_p, const sp_digit* a_p, sp_digit b_p)
  * a  A single precision integer.
  * b  A single precision digit.
  */
-static void sp_256_mul_d_sm2_8(sp_digit* r_p, const sp_digit* a_p, sp_digit b_p)
+static #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+void sp_256_mul_d_sm2_8(sp_digit* r_p, const sp_digit* a_p, sp_digit b_p)
+#else
+void sp_256_mul_d_sm2_8(sp_digit* r, const sp_digit* a, sp_digit b)
+#endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     register sp_digit* r asm ("r0") = (sp_digit*)r_p;
     register const sp_digit* a asm ("r1") = (const sp_digit*)a_p;
     register sp_digit b asm ("r2") = (sp_digit)b_p;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 
     __asm__ __volatile__ (
         /* A[0] * B */
@@ -5194,8 +5362,13 @@ static void sp_256_mul_d_sm2_8(sp_digit* r_p, const sp_digit* a_p, sp_digit b_p)
 #endif
         "stm	%[r]!, {r4}\n\t"
         "str	r5, [%[r]]\n\t"
-        : [r] "+r" (r),  [a] "+r" (a),  [b] "+r" (b)
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+        : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
         :
+#else
+        :
+        : [r] "r" (r), [a] "r" (a), [b] "r" (b)
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
         : "memory", "cc", "r3", "r4", "r5", "r6", "r7", "r8"
     );
 }
@@ -5211,11 +5384,17 @@ static void sp_256_mul_d_sm2_8(sp_digit* r_p, const sp_digit* a_p, sp_digit b_p)
  *
  * Note that this is an approximate div. It may give an answer 1 larger.
  */
-static sp_digit div_256_word_8(sp_digit d1_p, sp_digit d0_p, sp_digit div_p)
+static #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+sp_digit div_256_word_8(sp_digit d1_p, sp_digit d0_p, sp_digit div_p)
+#else
+sp_digit div_256_word_8(sp_digit d1, sp_digit d0, sp_digit div)
+#endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     register sp_digit d1 asm ("r0") = (sp_digit)d1_p;
     register sp_digit d0 asm ("r1") = (sp_digit)d0_p;
     register sp_digit div asm ("r2") = (sp_digit)div_p;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 
     __asm__ __volatile__ (
         "lsr	r6, %[div], #16\n\t"
@@ -5253,11 +5432,16 @@ static sp_digit div_256_word_8(sp_digit d1_p, sp_digit d0_p, sp_digit div_p)
         "sub	%[d0], %[d0], r3\n\t"
         "udiv	r3, %[d0], %[div]\n\t"
         "add	%[d1], r4, r3\n\t"
-        : [d1] "+r" (d1),  [d0] "+r" (d0),  [div] "+r" (div)
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+        : [d1] "+r" (d1), [d0] "+r" (d0), [div] "+r" (div)
         :
+#else
+        :
+        : [d1] "r" (d1), [d0] "r" (d0), [div] "r" (div)
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
         : "memory", "cc", "r3", "r12", "lr", "r4", "r5", "r6", "r7", "r8"
     );
-    return (uint32_t)(size_t)d1;
+    return (word32)(size_t)d1;
 }
 
 #else
@@ -5270,11 +5454,17 @@ static sp_digit div_256_word_8(sp_digit d1_p, sp_digit d0_p, sp_digit div_p)
  *
  * Note that this is an approximate div. It may give an answer 1 larger.
  */
-static sp_digit div_256_word_8(sp_digit d1_p, sp_digit d0_p, sp_digit div_p)
+static #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+sp_digit div_256_word_8(sp_digit d1_p, sp_digit d0_p, sp_digit div_p)
+#else
+sp_digit div_256_word_8(sp_digit d1, sp_digit d0, sp_digit div)
+#endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     register sp_digit d1 asm ("r0") = (sp_digit)d1_p;
     register sp_digit d0 asm ("r1") = (sp_digit)d0_p;
     register sp_digit div asm ("r2") = (sp_digit)div_p;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 
     __asm__ __volatile__ (
         "lsr	lr, %[div], #1\n\t"
@@ -5391,11 +5581,16 @@ static sp_digit div_256_word_8(sp_digit d1_p, sp_digit d0_p, sp_digit div_p)
         "subs	r6, %[div], r7\n\t"
         "sbc	r6, r6, r6\n\t"
         "sub	%[d1], r3, r6\n\t"
-        : [d1] "+r" (d1),  [d0] "+r" (d0),  [div] "+r" (div)
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+        : [d1] "+r" (d1), [d0] "+r" (d0), [div] "+r" (div)
         :
+#else
+        :
+        : [d1] "r" (d1), [d0] "r" (d0), [div] "r" (div)
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
         : "memory", "cc", "r3", "r12", "lr", "r4", "r5", "r6", "r7", "r8"
     );
-    return (uint32_t)(size_t)d1;
+    return (word32)(size_t)d1;
 }
 
 #endif
@@ -5432,10 +5627,16 @@ static void sp_256_mask_8(sp_digit* r, const sp_digit* a, sp_digit m)
  * return -ve, 0 or +ve if a is less than, equal to or greater than b
  * respectively.
  */
-static sp_int32 sp_256_cmp_sm2_8(const sp_digit* a_p, const sp_digit* b_p)
+static #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+sp_int32 sp_256_cmp_sm2_8(const sp_digit* a_p, const sp_digit* b_p)
+#else
+sp_int32 sp_256_cmp_sm2_8(const sp_digit* a, const sp_digit* b)
+#endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     register const sp_digit* a asm ("r0") = (const sp_digit*)a_p;
     register const sp_digit* b asm ("r1") = (const sp_digit*)b_p;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 
     __asm__ __volatile__ (
         "mov	r2, #-1\n\t"
@@ -5552,11 +5753,16 @@ static sp_int32 sp_256_cmp_sm2_8(const sp_digit* a_p, const sp_digit* b_p)
         "eor	r2, r2, r3\n\t"
 #endif /*WOLFSSL_SP_SMALL */
         "mov	%[a], r2\n\t"
-        : [a] "+r" (a),  [b] "+r" (b)
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+        : [a] "+r" (a), [b] "+r" (b)
         :
+#else
+        :
+        : [a] "r" (a), [b] "r" (b)
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
         : "memory", "cc", "r2", "r3", "r12", "lr", "r4", "r5", "r6"
     );
-    return (uint32_t)(size_t)a;
+    return (word32)(size_t)a;
 }
 
 /* Divide d in a and put remainder into r (m*d + r = a)
@@ -5834,12 +6040,19 @@ static int sp_256_point_to_ecc_point_8(const sp_point_256* p, ecc_point* pm)
  * m   Modulus (prime).
  * mp  Montgomery multiplier.
  */
-static SP_NOINLINE void sp_256_mont_mul_sm2_8(sp_digit* r_p, const sp_digit* a_p,
+static SP_NOINLINE #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+void sp_256_mont_mul_sm2_8(sp_digit* r_p, const sp_digit* a_p,
     const sp_digit* b_p, const sp_digit* m_p, sp_digit mp_p)
+#else
+void sp_256_mont_mul_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit* b,
+    const sp_digit* m, sp_digit mp)
+#endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     register sp_digit* r asm ("r0") = (sp_digit*)r_p;
     register const sp_digit* a asm ("r1") = (const sp_digit*)a_p;
     register const sp_digit* b asm ("r2") = (const sp_digit*)b_p;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 
     __asm__ __volatile__ (
         "sub	sp, sp, #0x44\n\t"
@@ -7967,13 +8180,26 @@ static SP_NOINLINE void sp_256_mont_mul_sm2_8(sp_digit* r_p, const sp_digit* a_p
         "ldr	%[r], [sp, #64]\n\t"
         "stm	%[r], {r1, r2, r3, r4, r5, r6, r7, r8}\n\t"
         "add	sp, sp, #0x44\n\t"
-        : [r] "+r" (r),  [a] "+r" (a),  [b] "+r" (b)
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+        : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
         :
+#else
+        :
+        : [r] "r" (r), [a] "r" (a), [b] "r" (b)
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
         : "memory", "cc", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "lr",
             "r12"
     );
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     (void)m_p;
+#else
+    (void)m;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     (void)mp_p;
+#else
+    (void)mp;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 }
 
 #elif defined(WOLFSSL_ARM_ARCH) && (WOLFSSL_ARM_ARCH < 7)
@@ -7986,12 +8212,19 @@ static SP_NOINLINE void sp_256_mont_mul_sm2_8(sp_digit* r_p, const sp_digit* a_p
  * m   Modulus (prime).
  * mp  Montgomery multiplier.
  */
-static SP_NOINLINE void sp_256_mont_mul_sm2_8(sp_digit* r_p, const sp_digit* a_p,
+static SP_NOINLINE #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+void sp_256_mont_mul_sm2_8(sp_digit* r_p, const sp_digit* a_p,
     const sp_digit* b_p, const sp_digit* m_p, sp_digit mp_p)
+#else
+void sp_256_mont_mul_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit* b,
+    const sp_digit* m, sp_digit mp)
+#endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     register sp_digit* r asm ("r0") = (sp_digit*)r_p;
     register const sp_digit* a asm ("r1") = (const sp_digit*)a_p;
     register const sp_digit* b asm ("r2") = (const sp_digit*)b_p;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 
     __asm__ __volatile__ (
         "sub	sp, sp, #0x44\n\t"
@@ -8476,13 +8709,26 @@ static SP_NOINLINE void sp_256_mont_mul_sm2_8(sp_digit* r_p, const sp_digit* a_p
         "ldr	%[r], [sp, #64]\n\t"
         "stm	%[r], {r1, r2, r3, r4, r5, r6, r7, r8}\n\t"
         "add	sp, sp, #0x44\n\t"
-        : [r] "+r" (r),  [a] "+r" (a),  [b] "+r" (b)
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+        : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
         :
+#else
+        :
+        : [r] "r" (r), [a] "r" (a), [b] "r" (b)
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
         : "memory", "cc", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10",
             "r11", "r12", "lr"
     );
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     (void)m_p;
+#else
+    (void)m;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     (void)mp_p;
+#else
+    (void)mp;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 }
 
 #else
@@ -8495,12 +8741,19 @@ static SP_NOINLINE void sp_256_mont_mul_sm2_8(sp_digit* r_p, const sp_digit* a_p
  * m   Modulus (prime).
  * mp  Montgomery multiplier.
  */
-static SP_NOINLINE void sp_256_mont_mul_sm2_8(sp_digit* r_p, const sp_digit* a_p,
+static SP_NOINLINE #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+void sp_256_mont_mul_sm2_8(sp_digit* r_p, const sp_digit* a_p,
     const sp_digit* b_p, const sp_digit* m_p, sp_digit mp_p)
+#else
+void sp_256_mont_mul_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit* b,
+    const sp_digit* m, sp_digit mp)
+#endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     register sp_digit* r asm ("r0") = (sp_digit*)r_p;
     register const sp_digit* a asm ("r1") = (const sp_digit*)a_p;
     register const sp_digit* b asm ("r2") = (const sp_digit*)b_p;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 
     __asm__ __volatile__ (
         "sub	sp, sp, #0x4c\n\t"
@@ -8763,13 +9016,26 @@ static SP_NOINLINE void sp_256_mont_mul_sm2_8(sp_digit* r_p, const sp_digit* a_p
         "ldr	%[r], [sp, #68]\n\t"
         "stm	%[r], {r1, r2, r3, r4, r5, r6, r7, r8}\n\t"
         "add	sp, sp, #0x4c\n\t"
-        : [r] "+r" (r),  [a] "+r" (a),  [b] "+r" (b)
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+        : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
         :
+#else
+        :
+        : [r] "r" (r), [a] "r" (a), [b] "r" (b)
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
         : "memory", "cc", "r3", "r4", "r5", "r6", "r10", "r11", "r12", "r7",
             "r8", "r9", "lr"
     );
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     (void)m_p;
+#else
+    (void)m;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     (void)mp_p;
+#else
+    (void)mp;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 }
 
 #endif
@@ -8781,11 +9047,18 @@ static SP_NOINLINE void sp_256_mont_mul_sm2_8(sp_digit* r_p, const sp_digit* a_p
  * m   Modulus (prime).
  * mp  Montgomery multiplier.
  */
-static SP_NOINLINE void sp_256_mont_sqr_sm2_8(sp_digit* r_p, const sp_digit* a_p,
+static SP_NOINLINE #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+void sp_256_mont_sqr_sm2_8(sp_digit* r_p, const sp_digit* a_p,
     const sp_digit* m_p, sp_digit mp_p)
+#else
+void sp_256_mont_sqr_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit* m,
+    sp_digit mp)
+#endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     register sp_digit* r asm ("r0") = (sp_digit*)r_p;
     register const sp_digit* a asm ("r1") = (const sp_digit*)a_p;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 
     __asm__ __volatile__ (
         "sub	sp, sp, #0x44\n\t"
@@ -9993,13 +10266,26 @@ static SP_NOINLINE void sp_256_mont_sqr_sm2_8(sp_digit* r_p, const sp_digit* a_p
         "ldr	%[r], [sp, #64]\n\t"
         "stm	%[r], {r1, r2, r3, r4, r5, r6, r7, r8}\n\t"
         "add	sp, sp, #0x44\n\t"
-        : [r] "+r" (r),  [a] "+r" (a)
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+        : [r] "+r" (r), [a] "+r" (a)
         :
+#else
+        :
+        : [r] "r" (r), [a] "r" (a)
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
         : "memory", "cc", "r2", "r3", "r4", "r5", "r6", "r7", "r12", "r8", "r9",
             "r10", "lr"
     );
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     (void)m_p;
+#else
+    (void)m;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     (void)mp_p;
+#else
+    (void)mp;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 }
 
 #elif defined(WOLFSSL_ARM_ARCH) && (WOLFSSL_ARM_ARCH < 7)
@@ -10010,11 +10296,18 @@ static SP_NOINLINE void sp_256_mont_sqr_sm2_8(sp_digit* r_p, const sp_digit* a_p
  * m   Modulus (prime).
  * mp  Montgomery multiplier.
  */
-static SP_NOINLINE void sp_256_mont_sqr_sm2_8(sp_digit* r_p, const sp_digit* a_p,
+static SP_NOINLINE #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+void sp_256_mont_sqr_sm2_8(sp_digit* r_p, const sp_digit* a_p,
     const sp_digit* m_p, sp_digit mp_p)
+#else
+void sp_256_mont_sqr_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit* m,
+    sp_digit mp)
+#endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     register sp_digit* r asm ("r0") = (sp_digit*)r_p;
     register const sp_digit* a asm ("r1") = (const sp_digit*)a_p;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 
     __asm__ __volatile__ (
         "sub	sp, sp, #0x44\n\t"
@@ -10391,13 +10684,26 @@ static SP_NOINLINE void sp_256_mont_sqr_sm2_8(sp_digit* r_p, const sp_digit* a_p
         "ldr	%[r], [sp, #64]\n\t"
         "stm	%[r], {r1, r2, r3, r4, r5, r6, r7, r8}\n\t"
         "add	sp, sp, #0x44\n\t"
-        : [r] "+r" (r),  [a] "+r" (a)
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+        : [r] "+r" (r), [a] "+r" (a)
         :
+#else
+        :
+        : [r] "r" (r), [a] "r" (a)
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
         : "memory", "cc", "r2", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10",
             "r11", "r12", "lr"
     );
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     (void)m_p;
+#else
+    (void)m;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     (void)mp_p;
+#else
+    (void)mp;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 }
 
 #else
@@ -10408,11 +10714,18 @@ static SP_NOINLINE void sp_256_mont_sqr_sm2_8(sp_digit* r_p, const sp_digit* a_p
  * m   Modulus (prime).
  * mp  Montgomery multiplier.
  */
-static SP_NOINLINE void sp_256_mont_sqr_sm2_8(sp_digit* r_p, const sp_digit* a_p,
+static SP_NOINLINE #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+void sp_256_mont_sqr_sm2_8(sp_digit* r_p, const sp_digit* a_p,
     const sp_digit* m_p, sp_digit mp_p)
+#else
+void sp_256_mont_sqr_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit* m,
+    sp_digit mp)
+#endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     register sp_digit* r asm ("r0") = (sp_digit*)r_p;
     register const sp_digit* a asm ("r1") = (const sp_digit*)a_p;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 
     __asm__ __volatile__ (
         "sub	sp, sp, #0x44\n\t"
@@ -10663,13 +10976,26 @@ static SP_NOINLINE void sp_256_mont_sqr_sm2_8(sp_digit* r_p, const sp_digit* a_p
         "ldr	%[r], [sp, #64]\n\t"
         "stm	%[r], {r1, r2, r3, r4, r5, r6, r7, r8}\n\t"
         "add	sp, sp, #0x44\n\t"
-        : [r] "+r" (r),  [a] "+r" (a)
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+        : [r] "+r" (r), [a] "+r" (a)
         :
+#else
+        :
+        : [r] "r" (r), [a] "r" (a)
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
         : "memory", "cc", "r2", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10",
             "r11", "r12", "lr"
     );
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     (void)m_p;
+#else
+    (void)m;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     (void)mp_p;
+#else
+    (void)mp;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 }
 
 #endif
@@ -10798,11 +11124,17 @@ static void sp_256_mont_inv_sm2_8(sp_digit* r, const sp_digit* a, sp_digit* td)
  * m   The single precision number representing the modulus.
  * mp  The digit representing the negative inverse of m mod 2^n.
  */
-static SP_NOINLINE void sp_256_mont_reduce_sm2_8(sp_digit* a_p, const sp_digit* m_p, sp_digit mp_p)
+static SP_NOINLINE #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+void sp_256_mont_reduce_sm2_8(sp_digit* a_p, const sp_digit* m_p, sp_digit mp_p)
+#else
+void sp_256_mont_reduce_sm2_8(sp_digit* a, const sp_digit* m, sp_digit mp)
+#endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     register sp_digit* a asm ("r0") = (sp_digit*)a_p;
     register const sp_digit* m asm ("r1") = (const sp_digit*)m_p;
     register sp_digit mp asm ("r2") = (sp_digit)mp_p;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 
     __asm__ __volatile__ (
 #if !(defined(WOLFSSL_ARM_ARCH) && (WOLFSSL_ARM_ARCH < 4))
@@ -11068,8 +11400,13 @@ static SP_NOINLINE void sp_256_mont_reduce_sm2_8(sp_digit* a_p, const sp_digit* 
         "str	r12, [%[a]]\n\t"
         "str	lr, [%[a], #4]\n\t"
         "mov	%[mp], r3\n\t"
-        : [a] "+r" (a),  [m] "+r" (m),  [mp] "+r" (mp)
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+        : [a] "+r" (a), [m] "+r" (m), [mp] "+r" (mp)
         :
+#else
+        :
+        : [a] "r" (a), [m] "r" (m), [mp] "r" (mp)
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
         : "memory", "cc", "r3", "r12", "lr", "r4", "r5", "r6", "r7", "r8", "r9",
             "r10", "r11"
     );
@@ -11083,11 +11420,17 @@ static SP_NOINLINE void sp_256_mont_reduce_sm2_8(sp_digit* a_p, const sp_digit* 
  * m   The single precision number representing the modulus.
  * mp  The digit representing the negative inverse of m mod 2^n.
  */
-static SP_NOINLINE void sp_256_mont_reduce_sm2_8(sp_digit* a_p, const sp_digit* m_p, sp_digit mp_p)
+static SP_NOINLINE #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+void sp_256_mont_reduce_sm2_8(sp_digit* a_p, const sp_digit* m_p, sp_digit mp_p)
+#else
+void sp_256_mont_reduce_sm2_8(sp_digit* a, const sp_digit* m, sp_digit mp)
+#endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     register sp_digit* a asm ("r0") = (sp_digit*)a_p;
     register const sp_digit* m asm ("r1") = (const sp_digit*)m_p;
     register sp_digit mp asm ("r2") = (sp_digit)mp_p;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 
     __asm__ __volatile__ (
         "ldr	r11, [%[m]]\n\t"
@@ -11172,8 +11515,13 @@ static SP_NOINLINE void sp_256_mont_reduce_sm2_8(sp_digit* a_p, const sp_digit* 
         "str	r12, [%[a]]\n\t"
         "str	lr, [%[a], #4]\n\t"
         "mov	%[mp], r3\n\t"
-        : [a] "+r" (a),  [m] "+r" (m),  [mp] "+r" (mp)
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+        : [a] "+r" (a), [m] "+r" (m), [mp] "+r" (mp)
         :
+#else
+        :
+        : [a] "r" (a), [m] "r" (m), [mp] "r" (mp)
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
         : "memory", "cc", "r3", "r12", "lr", "r4", "r5", "r6", "r7", "r8", "r9",
             "r10", "r11"
     );
@@ -11187,11 +11535,17 @@ static SP_NOINLINE void sp_256_mont_reduce_sm2_8(sp_digit* a_p, const sp_digit* 
  * m   The single precision number representing the modulus.
  * mp  The digit representing the negative inverse of m mod 2^n.
  */
-static SP_NOINLINE void sp_256_mont_reduce_sm2_8(sp_digit* a_p, const sp_digit* m_p, sp_digit mp_p)
+static SP_NOINLINE #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+void sp_256_mont_reduce_sm2_8(sp_digit* a_p, const sp_digit* m_p, sp_digit mp_p)
+#else
+void sp_256_mont_reduce_sm2_8(sp_digit* a, const sp_digit* m, sp_digit mp)
+#endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     register sp_digit* a asm ("r0") = (sp_digit*)a_p;
     register const sp_digit* m asm ("r1") = (const sp_digit*)m_p;
     register sp_digit mp asm ("r2") = (sp_digit)mp_p;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 
     __asm__ __volatile__ (
         /* i = 0 */
@@ -11258,8 +11612,13 @@ static SP_NOINLINE void sp_256_mont_reduce_sm2_8(sp_digit* a_p, const sp_digit* 
         "str	r7, [%[a], #12]\n\t"
         "str	r8, [%[a], #16]\n\t"
         "mov	%[mp], lr\n\t"
-        : [a] "+r" (a),  [m] "+r" (m),  [mp] "+r" (mp)
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+        : [a] "+r" (a), [m] "+r" (m), [mp] "+r" (mp)
         :
+#else
+        :
+        : [a] "r" (a), [m] "r" (m), [mp] "r" (mp)
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
         : "memory", "cc", "r3", "r12", "lr", "r4", "r5", "r6", "r7", "r8", "r9",
             "r10", "r11"
     );
@@ -11274,9 +11633,15 @@ static SP_NOINLINE void sp_256_mont_reduce_sm2_8(sp_digit* a_p, const sp_digit* 
  * m   The single precision number representing the modulus.
  * mp  The digit representing the negative inverse of m mod 2^n.
  */
-static SP_NOINLINE void sp_256_mont_reduce_sm2_8(sp_digit* a_p, const sp_digit* m_p, sp_digit mp_p)
+static SP_NOINLINE #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+void sp_256_mont_reduce_sm2_8(sp_digit* a_p, const sp_digit* m_p, sp_digit mp_p)
+#else
+void sp_256_mont_reduce_sm2_8(sp_digit* a, const sp_digit* m, sp_digit mp)
+#endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     register sp_digit* a asm ("r0") = (sp_digit*)a_p;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 
     __asm__ __volatile__ (
         "sub	sp, sp, #0x44\n\t"
@@ -11440,13 +11805,26 @@ static SP_NOINLINE void sp_256_mont_reduce_sm2_8(sp_digit* a_p, const sp_digit* 
         "ldr	%[a], [sp, #64]\n\t"
         "stm	%[a], {r1, r2, r3, r4, r5, r6, r7, r8}\n\t"
         "add	sp, sp, #0x44\n\t"
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
         : [a] "+r" (a)
         :
+#else
+        :
+        : [a] "r" (a)
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
         : "memory", "cc", "r1", "r2", "r3", "r4", "r5", "r6", "r7", "r8", "r9",
             "r10", "r11", "r12", "lr"
     );
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     (void)m_p;
+#else
+    (void)m;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     (void)mp_p;
+#else
+    (void)mp;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 }
 
 #if defined(WOLFSSL_ARM_ARCH) && (WOLFSSL_ARM_ARCH < 4)
@@ -11456,12 +11834,18 @@ static SP_NOINLINE void sp_256_mont_reduce_sm2_8(sp_digit* a_p, const sp_digit* 
  * m   The single precision number representing the modulus.
  * mp  The digit representing the negative inverse of m mod 2^n.
  */
-static SP_NOINLINE void sp_256_mont_reduce_order_sm2_8(sp_digit* a_p, const sp_digit* m_p,
+static SP_NOINLINE #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+void sp_256_mont_reduce_order_sm2_8(sp_digit* a_p, const sp_digit* m_p,
     sp_digit mp_p)
+#else
+void sp_256_mont_reduce_order_sm2_8(sp_digit* a, const sp_digit* m, sp_digit mp)
+#endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     register sp_digit* a asm ("r0") = (sp_digit*)a_p;
     register const sp_digit* m asm ("r1") = (const sp_digit*)m_p;
     register sp_digit mp asm ("r2") = (sp_digit)mp_p;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 
     __asm__ __volatile__ (
 #if !(defined(WOLFSSL_ARM_ARCH) && (WOLFSSL_ARM_ARCH < 4))
@@ -11727,8 +12111,13 @@ static SP_NOINLINE void sp_256_mont_reduce_order_sm2_8(sp_digit* a_p, const sp_d
         "str	r12, [%[a]]\n\t"
         "str	lr, [%[a], #4]\n\t"
         "mov	%[mp], r3\n\t"
-        : [a] "+r" (a),  [m] "+r" (m),  [mp] "+r" (mp)
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+        : [a] "+r" (a), [m] "+r" (m), [mp] "+r" (mp)
         :
+#else
+        :
+        : [a] "r" (a), [m] "r" (m), [mp] "r" (mp)
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
         : "memory", "cc", "r3", "r12", "lr", "r4", "r5", "r6", "r7", "r8", "r9",
             "r10", "r11"
     );
@@ -11742,12 +12131,18 @@ static SP_NOINLINE void sp_256_mont_reduce_order_sm2_8(sp_digit* a_p, const sp_d
  * m   The single precision number representing the modulus.
  * mp  The digit representing the negative inverse of m mod 2^n.
  */
-static SP_NOINLINE void sp_256_mont_reduce_order_sm2_8(sp_digit* a_p, const sp_digit* m_p,
+static SP_NOINLINE #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+void sp_256_mont_reduce_order_sm2_8(sp_digit* a_p, const sp_digit* m_p,
     sp_digit mp_p)
+#else
+void sp_256_mont_reduce_order_sm2_8(sp_digit* a, const sp_digit* m, sp_digit mp)
+#endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     register sp_digit* a asm ("r0") = (sp_digit*)a_p;
     register const sp_digit* m asm ("r1") = (const sp_digit*)m_p;
     register sp_digit mp asm ("r2") = (sp_digit)mp_p;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 
     __asm__ __volatile__ (
         "ldr	r11, [%[m]]\n\t"
@@ -11832,8 +12227,13 @@ static SP_NOINLINE void sp_256_mont_reduce_order_sm2_8(sp_digit* a_p, const sp_d
         "str	r12, [%[a]]\n\t"
         "str	lr, [%[a], #4]\n\t"
         "mov	%[mp], r3\n\t"
-        : [a] "+r" (a),  [m] "+r" (m),  [mp] "+r" (mp)
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+        : [a] "+r" (a), [m] "+r" (m), [mp] "+r" (mp)
         :
+#else
+        :
+        : [a] "r" (a), [m] "r" (m), [mp] "r" (mp)
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
         : "memory", "cc", "r3", "r12", "lr", "r4", "r5", "r6", "r7", "r8", "r9",
             "r10", "r11"
     );
@@ -11847,12 +12247,18 @@ static SP_NOINLINE void sp_256_mont_reduce_order_sm2_8(sp_digit* a_p, const sp_d
  * m   The single precision number representing the modulus.
  * mp  The digit representing the negative inverse of m mod 2^n.
  */
-static SP_NOINLINE void sp_256_mont_reduce_order_sm2_8(sp_digit* a_p, const sp_digit* m_p,
+static SP_NOINLINE #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+void sp_256_mont_reduce_order_sm2_8(sp_digit* a_p, const sp_digit* m_p,
     sp_digit mp_p)
+#else
+void sp_256_mont_reduce_order_sm2_8(sp_digit* a, const sp_digit* m, sp_digit mp)
+#endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     register sp_digit* a asm ("r0") = (sp_digit*)a_p;
     register const sp_digit* m asm ("r1") = (const sp_digit*)m_p;
     register sp_digit mp asm ("r2") = (sp_digit)mp_p;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 
     __asm__ __volatile__ (
         /* i = 0 */
@@ -11919,8 +12325,13 @@ static SP_NOINLINE void sp_256_mont_reduce_order_sm2_8(sp_digit* a_p, const sp_d
         "str	r7, [%[a], #12]\n\t"
         "str	r8, [%[a], #16]\n\t"
         "mov	%[mp], lr\n\t"
-        : [a] "+r" (a),  [m] "+r" (m),  [mp] "+r" (mp)
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+        : [a] "+r" (a), [m] "+r" (m), [mp] "+r" (mp)
         :
+#else
+        :
+        : [a] "r" (a), [m] "r" (m), [mp] "r" (mp)
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
         : "memory", "cc", "r3", "r12", "lr", "r4", "r5", "r6", "r7", "r8", "r9",
             "r10", "r11"
     );
@@ -11976,12 +12387,19 @@ static void sp_256_map_sm2_8(sp_point_256* r, const sp_point_256* p,
  * b   Second number to add in Montgomery form.
  * m   Modulus (prime).
  */
-static void sp_256_mont_add_sm2_8(sp_digit* r_p, const sp_digit* a_p,
+static #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+void sp_256_mont_add_sm2_8(sp_digit* r_p, const sp_digit* a_p,
     const sp_digit* b_p, const sp_digit* m_p)
+#else
+void sp_256_mont_add_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit* b,
+    const sp_digit* m)
+#endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     register sp_digit* r asm ("r0") = (sp_digit*)r_p;
     register const sp_digit* a asm ("r1") = (const sp_digit*)a_p;
     register const sp_digit* b asm ("r2") = (const sp_digit*)b_p;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 
     __asm__ __volatile__ (
         "mov	lr, #0\n\t"
@@ -12019,12 +12437,21 @@ static void sp_256_mont_add_sm2_8(sp_digit* r_p, const sp_digit* a_p,
         "sbcs	r11, r11, lr\n\t"
         "sbc	r12, r12, lr, lsl #1\n\t"
         "stm	%[r], {r5, r6, r7, r8, r9, r10, r11, r12}\n\t"
-        : [r] "+r" (r),  [a] "+r" (a),  [b] "+r" (b)
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+        : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
         :
+#else
+        :
+        : [r] "r" (r), [a] "r" (a), [b] "r" (b)
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
         : "memory", "cc", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10",
             "r11", "r12", "lr"
     );
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     (void)m_p;
+#else
+    (void)m;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 }
 
 /* Double a Montgomery form number (r = a + a % m).
@@ -12033,11 +12460,17 @@ static void sp_256_mont_add_sm2_8(sp_digit* r_p, const sp_digit* a_p,
  * a   Number to double in Montgomery form.
  * m   Modulus (prime).
  */
-static void sp_256_mont_dbl_sm2_8(sp_digit* r_p, const sp_digit* a_p,
+static #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+void sp_256_mont_dbl_sm2_8(sp_digit* r_p, const sp_digit* a_p,
     const sp_digit* m_p)
+#else
+void sp_256_mont_dbl_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit* m)
+#endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     register sp_digit* r asm ("r0") = (sp_digit*)r_p;
     register const sp_digit* a asm ("r1") = (const sp_digit*)a_p;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 
     __asm__ __volatile__ (
         "mov	r2, #0\n\t"
@@ -12071,12 +12504,21 @@ static void sp_256_mont_dbl_sm2_8(sp_digit* r_p, const sp_digit* a_p,
         "sbcs	r10, r10, r2\n\t"
         "sbc	r11, r11, r2, lsl #1\n\t"
         "stm	%[r], {r4, r5, r6, r7, r8, r9, r10, r11}\n\t"
-        : [r] "+r" (r),  [a] "+r" (a)
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+        : [r] "+r" (r), [a] "+r" (a)
         :
+#else
+        :
+        : [r] "r" (r), [a] "r" (a)
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
         : "memory", "cc", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11",
             "r2"
     );
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     (void)m_p;
+#else
+    (void)m;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 }
 
 /* Triple a Montgomery form number (r = a + a + a % m).
@@ -12085,11 +12527,17 @@ static void sp_256_mont_dbl_sm2_8(sp_digit* r_p, const sp_digit* a_p,
  * a   Number to triple in Montgomery form.
  * m   Modulus (prime).
  */
-static void sp_256_mont_tpl_sm2_8(sp_digit* r_p, const sp_digit* a_p,
+static #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+void sp_256_mont_tpl_sm2_8(sp_digit* r_p, const sp_digit* a_p,
     const sp_digit* m_p)
+#else
+void sp_256_mont_tpl_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit* m)
+#endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     register sp_digit* r asm ("r0") = (sp_digit*)r_p;
     register const sp_digit* a asm ("r1") = (const sp_digit*)a_p;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 
     __asm__ __volatile__ (
         "mov	r12, #0\n\t"
@@ -12155,12 +12603,21 @@ static void sp_256_mont_tpl_sm2_8(sp_digit* r_p, const sp_digit* a_p,
         "sbcs	r10, r10, r12\n\t"
         "sbc	r11, r11, r12, lsl #1\n\t"
         "stm	%[r], {r4, r5, r6, r7, r8, r9, r10, r11}\n\t"
-        : [r] "+r" (r),  [a] "+r" (a)
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+        : [r] "+r" (r), [a] "+r" (a)
         :
+#else
+        :
+        : [r] "r" (r), [a] "r" (a)
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
         : "memory", "cc", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11",
             "r2", "r3", "r12"
     );
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     (void)m_p;
+#else
+    (void)m;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 }
 
 /* Subtract two Montgomery form numbers (r = a - b % m).
@@ -12170,12 +12627,19 @@ static void sp_256_mont_tpl_sm2_8(sp_digit* r_p, const sp_digit* a_p,
  * b   Number to subtract with in Montgomery form.
  * m   Modulus (prime).
  */
-static void sp_256_mont_sub_sm2_8(sp_digit* r_p, const sp_digit* a_p,
+static #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+void sp_256_mont_sub_sm2_8(sp_digit* r_p, const sp_digit* a_p,
     const sp_digit* b_p, const sp_digit* m_p)
+#else
+void sp_256_mont_sub_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit* b,
+    const sp_digit* m)
+#endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     register sp_digit* r asm ("r0") = (sp_digit*)r_p;
     register const sp_digit* a asm ("r1") = (const sp_digit*)a_p;
     register const sp_digit* b asm ("r2") = (const sp_digit*)b_p;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 
     __asm__ __volatile__ (
         "mov	lr, #0\n\t"
@@ -12211,12 +12675,21 @@ static void sp_256_mont_sub_sm2_8(sp_digit* r_p, const sp_digit* a_p,
         "adcs	r11, r11, lr\n\t"
         "adc	r12, r12, lr, lsl #1\n\t"
         "stm	%[r], {r5, r6, r7, r8, r9, r10, r11, r12}\n\t"
-        : [r] "+r" (r),  [a] "+r" (a),  [b] "+r" (b)
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+        : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
         :
+#else
+        :
+        : [r] "r" (r), [a] "r" (a), [b] "r" (b)
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
         : "memory", "cc", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10",
             "r11", "r12", "lr"
     );
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     (void)m_p;
+#else
+    (void)m;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 }
 
 /* Divide the number by 2 mod the modulus (prime). (r = a / 2 % m)
@@ -12225,12 +12698,18 @@ static void sp_256_mont_sub_sm2_8(sp_digit* r_p, const sp_digit* a_p,
  * a  Number to divide.
  * m  Modulus (prime).
  */
-static void sp_256_mont_div2_sm2_8(sp_digit* r_p, const sp_digit* a_p,
+static #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+void sp_256_mont_div2_sm2_8(sp_digit* r_p, const sp_digit* a_p,
     const sp_digit* m_p)
+#else
+void sp_256_mont_div2_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit* m)
+#endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     register sp_digit* r asm ("r0") = (sp_digit*)r_p;
     register const sp_digit* a asm ("r1") = (const sp_digit*)a_p;
     register const sp_digit* m asm ("r2") = (const sp_digit*)m_p;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 
     __asm__ __volatile__ (
         "ldm	%[a], {r4, r5, r6, r7}\n\t"
@@ -12290,8 +12769,13 @@ static void sp_256_mont_div2_sm2_8(sp_digit* r_p, const sp_digit* a_p,
         "orr	r10, r10, r7, lsl #31\n\t"
         "orr	r11, r11, r3, lsl #31\n\t"
         "stm	%[r], {r8, r9, r10, r11}\n\t"
-        : [r] "+r" (r),  [a] "+r" (a),  [m] "+r" (m)
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+        : [r] "+r" (r), [a] "+r" (a), [m] "+r" (m)
         :
+#else
+        :
+        : [r] "r" (r), [a] "r" (a), [m] "r" (m)
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
         : "memory", "cc", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11",
             "r3"
     );
@@ -13544,7 +14028,7 @@ typedef struct sp_cache_256_t {
     /* Precomputation table for point. */
     sp_table_entry_256 table[16];
     /* Count of entries in table. */
-    uint32_t cnt;
+    word32 cnt;
     /* Point and table set in entry. */
     int set;
 } sp_cache_256_t;
@@ -13572,7 +14056,7 @@ static void sp_ecc_get_cache_256(const sp_point_256* g, sp_cache_256_t** cache)
 {
     int i;
     int j;
-    uint32_t least;
+    word32 least;
 
     if (sp_cache_256_inited == 0) {
         for (i=0; i<FP_ENTRIES; i++) {
@@ -13965,7 +14449,7 @@ typedef struct sp_cache_256_t {
     /* Precomputation table for point. */
     sp_table_entry_256 table[256];
     /* Count of entries in table. */
-    uint32_t cnt;
+    word32 cnt;
     /* Point and table set in entry. */
     int set;
 } sp_cache_256_t;
@@ -13993,7 +14477,7 @@ static void sp_ecc_get_cache_256(const sp_point_256* g, sp_cache_256_t** cache)
 {
     int i;
     int j;
-    uint32_t least;
+    word32 least;
 
     if (sp_cache_256_inited == 0) {
         for (i=0; i<FP_ENTRIES; i++) {
@@ -15799,9 +16283,15 @@ int sp_ecc_mulmod_base_add_sm2_256(const mp_int* km, const ecc_point* am,
  *
  * a  A single precision integer.
  */
-static void sp_256_add_one_sm2_8(sp_digit* a_p)
+static #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+void sp_256_add_one_sm2_8(sp_digit* a_p)
+#else
+void sp_256_add_one_sm2_8(sp_digit* a)
+#endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     register sp_digit* a asm ("r0") = (sp_digit*)a_p;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 
     __asm__ __volatile__ (
         "ldm	%[a], {r1, r2, r3, r4}\n\t"
@@ -15816,8 +16306,13 @@ static void sp_256_add_one_sm2_8(sp_digit* a_p)
         "adcs	r3, r3, #0\n\t"
         "adcs	r4, r4, #0\n\t"
         "stm	%[a]!, {r1, r2, r3, r4}\n\t"
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
         : [a] "+r" (a)
         :
+#else
+        :
+        : [a] "r" (a)
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
         : "memory", "cc", "r1", "r2", "r3", "r4"
     );
 }
@@ -15835,7 +16330,8 @@ static void sp_256_from_bin(sp_digit* r, int size, const byte* a, int n)
     int j;
     byte* d;
 
-    for (i = n - 1,j = 0; i >= 3; i -= 4) {
+    j = 0;
+    for (i = n - 1; i >= 3; i -= 4) {
         r[j]  = ((sp_digit)a[i - 0] <<  0) |
                 ((sp_digit)a[i - 1] <<  8) |
                 ((sp_digit)a[i - 2] << 16) |
@@ -15846,12 +16342,20 @@ static void sp_256_from_bin(sp_digit* r, int size, const byte* a, int n)
     if (i >= 0) {
         r[j] = 0;
 
-        d = (byte*)r;
+        d = (byte*)(r + j);
+#ifdef BIG_ENDIAN_ORDER
         switch (i) {
-            case 2: d[n - 1 - 2] = a[2]; //fallthrough
-            case 1: d[n - 1 - 1] = a[1]; //fallthrough
-            case 0: d[n - 1 - 0] = a[0]; //fallthrough
+            case 2: d[1] = *(a++); //fallthrough
+            case 1: d[2] = *(a++); //fallthrough
+            case 0: d[3] = *a    ; //fallthrough
         }
+#else
+        switch (i) {
+            case 2: d[2] = a[2]; //fallthrough
+            case 1: d[1] = a[1]; //fallthrough
+            case 0: d[0] = a[0]; //fallthrough
+        }
+#endif
         j++;
     }
 
@@ -16195,12 +16699,18 @@ int sp_ecc_secret_gen_256_nb(sp_ecc_ctx_t* sp_ctx, const mp_int* priv,
  * a  A single precision integer.
  * b  A single precision integer.
  */
-static sp_digit sp_256_sub_sm2_8(sp_digit* r_p, const sp_digit* a_p,
+static #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+sp_digit sp_256_sub_sm2_8(sp_digit* r_p, const sp_digit* a_p,
     const sp_digit* b_p)
+#else
+sp_digit sp_256_sub_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit* b)
+#endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     register sp_digit* r asm ("r0") = (sp_digit*)r_p;
     register const sp_digit* a asm ("r1") = (const sp_digit*)a_p;
     register const sp_digit* b asm ("r2") = (const sp_digit*)b_p;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 
     __asm__ __volatile__ (
         "mov	r12, #0\n\t"
@@ -16219,12 +16729,17 @@ static sp_digit sp_256_sub_sm2_8(sp_digit* r_p, const sp_digit* a_p,
         "cmp	%[a], lr\n\t"
         "bne	L_sp_256_sub_sm2_8_word_%=\n\t"
         "mov	%[r], r12\n\t"
-        : [r] "+r" (r),  [a] "+r" (a),  [b] "+r" (b)
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+        : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
         :
+#else
+        :
+        : [r] "r" (r), [a] "r" (a), [b] "r" (b)
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
         : "memory", "cc", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10",
             "r12", "lr"
     );
-    return (uint32_t)(size_t)r;
+    return (word32)(size_t)r;
 }
 
 #else
@@ -16234,12 +16749,18 @@ static sp_digit sp_256_sub_sm2_8(sp_digit* r_p, const sp_digit* a_p,
  * a  A single precision integer.
  * b  A single precision integer.
  */
-static sp_digit sp_256_sub_sm2_8(sp_digit* r_p, const sp_digit* a_p,
+static #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+sp_digit sp_256_sub_sm2_8(sp_digit* r_p, const sp_digit* a_p,
     const sp_digit* b_p)
+#else
+sp_digit sp_256_sub_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit* b)
+#endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     register sp_digit* r asm ("r0") = (sp_digit*)r_p;
     register const sp_digit* a asm ("r1") = (const sp_digit*)a_p;
     register const sp_digit* b asm ("r2") = (const sp_digit*)b_p;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 
     __asm__ __volatile__ (
         "ldm	%[a]!, {r3, r4, r5, r6}\n\t"
@@ -16257,11 +16778,16 @@ static sp_digit sp_256_sub_sm2_8(sp_digit* r_p, const sp_digit* a_p,
         "sbcs	r6, r6, r10\n\t"
         "stm	%[r]!, {r3, r4, r5, r6}\n\t"
         "sbc	%[r], r6, r6\n\t"
-        : [r] "+r" (r),  [a] "+r" (a),  [b] "+r" (b)
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+        : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
         :
+#else
+        :
+        : [r] "r" (r), [a] "r" (a), [b] "r" (b)
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
         : "memory", "cc", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10"
     );
-    return (uint32_t)(size_t)r;
+    return (word32)(size_t)r;
 }
 
 #endif /* WOLFSSL_SP_SMALL */
@@ -16277,13 +16803,20 @@ static sp_digit sp_256_sub_sm2_8(sp_digit* r_p, const sp_digit* a_p,
  * b  A single precision number to add.
  * m  Mask value to apply.
  */
-static sp_digit sp_256_cond_add_sm2_8(sp_digit* r_p, const sp_digit* a_p,
+static #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+sp_digit sp_256_cond_add_sm2_8(sp_digit* r_p, const sp_digit* a_p,
     const sp_digit* b_p, sp_digit m_p)
+#else
+sp_digit sp_256_cond_add_sm2_8(sp_digit* r, const sp_digit* a,
+    const sp_digit* b, sp_digit m)
+#endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     register sp_digit* r asm ("r0") = (sp_digit*)r_p;
     register const sp_digit* a asm ("r1") = (const sp_digit*)a_p;
     register const sp_digit* b asm ("r2") = (const sp_digit*)b_p;
     register sp_digit m asm ("r3") = (sp_digit)m_p;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 
     __asm__ __volatile__ (
         "mov	lr, #0\n\t"
@@ -16302,11 +16835,16 @@ static sp_digit sp_256_cond_add_sm2_8(sp_digit* r_p, const sp_digit* a_p,
         "cmp	r12, #32\n\t"
         "blt	L_sp_256_cond_add_sm2_8_words_%=\n\t"
         "mov	%[r], lr\n\t"
-        : [r] "+r" (r),  [a] "+r" (a),  [b] "+r" (b),  [m] "+r" (m)
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+        : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b), [m] "+r" (m)
         :
+#else
+        :
+        : [r] "r" (r), [a] "r" (a), [b] "r" (b), [m] "r" (m)
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
         : "memory", "cc", "r12", "lr", "r4", "r5", "r6"
     );
-    return (uint32_t)(size_t)r;
+    return (word32)(size_t)r;
 }
 
 #else
@@ -16318,13 +16856,20 @@ static sp_digit sp_256_cond_add_sm2_8(sp_digit* r_p, const sp_digit* a_p,
  * b  A single precision number to add.
  * m  Mask value to apply.
  */
-static sp_digit sp_256_cond_add_sm2_8(sp_digit* r_p, const sp_digit* a_p,
+static #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+sp_digit sp_256_cond_add_sm2_8(sp_digit* r_p, const sp_digit* a_p,
     const sp_digit* b_p, sp_digit m_p)
+#else
+sp_digit sp_256_cond_add_sm2_8(sp_digit* r, const sp_digit* a,
+    const sp_digit* b, sp_digit m)
+#endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
 {
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     register sp_digit* r asm ("r0") = (sp_digit*)r_p;
     register const sp_digit* a asm ("r1") = (const sp_digit*)a_p;
     register const sp_digit* b asm ("r2") = (const sp_digit*)b_p;
     register sp_digit m asm ("r3") = (sp_digit)m_p;
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 
     __asm__ __volatile__ (
         "mov	r8, #0\n\t"
@@ -16357,11 +16902,16 @@ static sp_digit sp_256_cond_add_sm2_8(sp_digit* r_p, const sp_digit* a_p,
         "adcs	r5, r5, r7\n\t"
         "stm	%[r]!, {r4, r5}\n\t"
         "adc	%[r], r8, r8\n\t"
-        : [r] "+r" (r),  [a] "+r" (a),  [b] "+r" (b),  [m] "+r" (m)
+#ifndef WOLFSSL_NO_VAR_ASSIGN_REG
+        : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b), [m] "+r" (m)
         :
+#else
+        :
+        : [r] "r" (r), [a] "r" (a), [b] "r" (b), [m] "r" (m)
+#endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
         : "memory", "cc", "r12", "lr", "r4", "r5", "r6", "r7", "r8"
     );
-    return (uint32_t)(size_t)r;
+    return (word32)(size_t)r;
 }
 
 #endif /* WOLFSSL_SP_SMALL */
@@ -17266,7 +17816,7 @@ int sp_ecc_map_sm2_256(mp_int* pX, mp_int* pY, mp_int* pZ)
 #endif /* WOLFSSL_PUBLIC_ECC_ADD_DBL */
 #ifdef HAVE_COMP_KEY
 /* Square root power for the P256 curve. */
-static const uint32_t p256_sm2_sqrt_power[8] = {
+static const word32 p256_sm2_sqrt_power[8] = {
     0x00000000,0x40000000,0xc0000000,0xffffffff,0xffffffff,0xffffffff,
     0xbfffffff,0x3fffffff
 };

--- a/sp_sm2_arm64.c
+++ b/sp_sm2_arm64.c
@@ -1,6 +1,6 @@
 /* sp.c
  *
- * Copyright (C) 2006-2024 wolfSSL Inc.
+ * Copyright (C) 2006-2025 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *
@@ -21,16 +21,11 @@
 
 /* Implementation by Sean Parkinson. */
 
-#ifdef HAVE_CONFIG_H
-    #include <config.h>
-#endif
-
-#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 
 #if defined(WOLFSSL_HAVE_SP_RSA) || defined(WOLFSSL_HAVE_SP_DH) || \
     defined(WOLFSSL_HAVE_SP_ECC)
 
-#include <wolfssl/wolfcrypt/error-crypt.h>
 #include <wolfssl/wolfcrypt/cpuid.h>
 #ifdef NO_INLINE
     #include <wolfssl/wolfcrypt/misc.h>
@@ -2756,13 +2751,13 @@ static void sp_256_proj_point_add_sub_sm2_4(sp_point_256* ra,
 /* Structure used to describe recoding of scalar multiplication. */
 typedef struct ecc_recode_256 {
     /* Index into pre-computation table. */
-    uint8_t i;
+    word8 i;
     /* Use the negative of the point. */
-    uint8_t neg;
+    word8 neg;
 } ecc_recode_256;
 
 /* The index into pre-computation table to use. */
-static const uint8_t recode_index_4_6[66] = {
+static const word8 recode_index_4_6[66] = {
      0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15,
     16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
     32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17,
@@ -2771,7 +2766,7 @@ static const uint8_t recode_index_4_6[66] = {
 };
 
 /* Whether to negate y-ordinate. */
-static const uint8_t recode_neg_4_6[66] = {
+static const word8 recode_neg_4_6[66] = {
      0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
      0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
      1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
@@ -2789,7 +2784,7 @@ static void sp_256_ecc_recode_6_4(const sp_digit* k, ecc_recode_256* v)
 {
     int i;
     int j;
-    uint8_t y;
+    word8 y;
     int carry = 0;
     int o;
     sp_digit n;
@@ -2798,7 +2793,7 @@ static void sp_256_ecc_recode_6_4(const sp_digit* k, ecc_recode_256* v)
     n = k[j];
     o = 0;
     for (i=0; i<43; i++) {
-        y = (uint8_t)(int8_t)n;
+        y = (word8)(int8_t)n;
         if (o + 6 < 64) {
             y &= 0x3f;
             n >>= 6;
@@ -2812,12 +2807,12 @@ static void sp_256_ecc_recode_6_4(const sp_digit* k, ecc_recode_256* v)
         }
         else if (++j < 4) {
             n = k[j];
-            y |= (uint8_t)((n << (64 - o)) & 0x3f);
+            y |= (word8)((n << (64 - o)) & 0x3f);
             o -= 58;
             n >>= o;
         }
 
-        y += (uint8_t)carry;
+        y = (word8)(y + carry);
         v[i].i = recode_index_4_6[y];
         v[i].neg = recode_neg_4_6[y];
         carry = (y >> 6) + v[i].neg;
@@ -3464,7 +3459,7 @@ typedef struct sp_cache_256_t {
     /* Precomputation table for point. */
     sp_table_entry_256 table[64];
     /* Count of entries in table. */
-    uint32_t cnt;
+    word32 cnt;
     /* Point and table set in entry. */
     int set;
 } sp_cache_256_t;
@@ -3492,7 +3487,7 @@ static void sp_ecc_get_cache_256(const sp_point_256* g, sp_cache_256_t** cache)
 {
     int i;
     int j;
-    uint32_t least;
+    word32 least;
 
     if (sp_cache_256_inited == 0) {
         for (i=0; i<FP_ENTRIES; i++) {
@@ -3894,7 +3889,7 @@ typedef struct sp_cache_256_t {
     /* Precomputation table for point. */
     sp_table_entry_256 table[256];
     /* Count of entries in table. */
-    uint32_t cnt;
+    word32 cnt;
     /* Point and table set in entry. */
     int set;
 } sp_cache_256_t;
@@ -3922,7 +3917,7 @@ static void sp_ecc_get_cache_256(const sp_point_256* g, sp_cache_256_t** cache)
 {
     int i;
     int j;
-    uint32_t least;
+    word32 least;
 
     if (sp_cache_256_inited == 0) {
         for (i=0; i<FP_ENTRIES; i++) {
@@ -5837,7 +5832,7 @@ static int sp_256_ecc_mulmod_base_sm2_4(sp_point_256* r, const sp_digit* k,
 #endif /* WC_NO_CACHE_RESISTANT */
 #else
 /* The index into pre-computation table to use. */
-static const uint8_t recode_index_4_7[130] = {
+static const word8 recode_index_4_7[130] = {
      0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15,
     16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
     32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47,
@@ -5850,7 +5845,7 @@ static const uint8_t recode_index_4_7[130] = {
 };
 
 /* Whether to negate y-ordinate. */
-static const uint8_t recode_neg_4_7[130] = {
+static const word8 recode_neg_4_7[130] = {
      0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
      0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
      0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
@@ -5872,7 +5867,7 @@ static void sp_256_ecc_recode_7_4(const sp_digit* k, ecc_recode_256* v)
 {
     int i;
     int j;
-    uint8_t y;
+    word8 y;
     int carry = 0;
     int o;
     sp_digit n;
@@ -5881,7 +5876,7 @@ static void sp_256_ecc_recode_7_4(const sp_digit* k, ecc_recode_256* v)
     n = k[j];
     o = 0;
     for (i=0; i<37; i++) {
-        y = (uint8_t)(int8_t)n;
+        y = (word8)(int8_t)n;
         if (o + 7 < 64) {
             y &= 0x7f;
             n >>= 7;
@@ -5895,12 +5890,12 @@ static void sp_256_ecc_recode_7_4(const sp_digit* k, ecc_recode_256* v)
         }
         else if (++j < 4) {
             n = k[j];
-            y |= (uint8_t)((n << (64 - o)) & 0x7f);
+            y |= (word8)((n << (64 - o)) & 0x7f);
             o -= 57;
             n >>= o;
         }
 
-        y += (uint8_t)carry;
+        y = (word8)(y + carry);
         v[i].i = recode_index_4_7[y];
         v[i].neg = recode_neg_4_7[y];
         carry = (y >> 7) + v[i].neg;
@@ -18004,7 +17999,7 @@ static int sp_256_ecc_mulmod_add_only_sm2_4(sp_point_256* r, const sp_point_256*
             p->infinity = !v[i].i;
             sp_256_sub_sm2_4(negy, p256_sm2_mod, p->y);
             sp_256_norm_4(negy);
-            sp_256_cond_copy_sm2_4(p->y, negy, 0 - v[i].neg);
+            sp_256_cond_copy_sm2_4(p->y, negy, (sp_digit)(0 - v[i].neg));
             sp_256_proj_point_add_qz1_sm2_4(rt, rt, p, tmp);
         }
         if (map != 0) {
@@ -20216,7 +20211,7 @@ int sp_ecc_map_sm2_256(mp_int* pX, mp_int* pY, mp_int* pZ)
 #endif /* WOLFSSL_PUBLIC_ECC_ADD_DBL */
 #ifdef HAVE_COMP_KEY
 /* Square root power for the P256 curve. */
-static const uint64_t p256_sm2_sqrt_power[4] = {
+static const word64 p256_sm2_sqrt_power[4] = {
     0x4000000000000000,0xffffffffc0000000,0xffffffffffffffff,
     0x3fffffffbfffffff
 };

--- a/sp_sm2_c32.c
+++ b/sp_sm2_c32.c
@@ -1,6 +1,6 @@
 /* sp.c
  *
- * Copyright (C) 2006-2024 wolfSSL Inc.
+ * Copyright (C) 2006-2025 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *
@@ -21,16 +21,11 @@
 
 /* Implementation by Sean Parkinson. */
 
-#ifdef HAVE_CONFIG_H
-    #include <config.h>
-#endif
-
-#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 
 #if defined(WOLFSSL_HAVE_SP_RSA) || defined(WOLFSSL_HAVE_SP_DH) || \
     defined(WOLFSSL_HAVE_SP_ECC)
 
-#include <wolfssl/wolfcrypt/error-crypt.h>
 #include <wolfssl/wolfcrypt/cpuid.h>
 #ifdef NO_INLINE
     #include <wolfssl/wolfcrypt/misc.h>
@@ -239,29 +234,29 @@ SP_NOINLINE static void sp_256_mul_sm2_9(sp_digit* r, const sp_digit* a,
     t0 = ((sp_int64)a[ 0]) * b[ 0];
     t1 = ((sp_int64)a[ 0]) * b[ 1]
        + ((sp_int64)a[ 1]) * b[ 0];
-    t[ 0] = t0 & 0x1fffffff; t1 += t0 >> 29;
+    t[ 0] = (sp_digit)(t0 & 0x1fffffff); t1 += t0 >> 29;
     t0 = ((sp_int64)a[ 0]) * b[ 2]
        + ((sp_int64)a[ 1]) * b[ 1]
        + ((sp_int64)a[ 2]) * b[ 0];
-    t[ 1] = t1 & 0x1fffffff; t0 += t1 >> 29;
+    t[ 1] = (sp_digit)(t1 & 0x1fffffff); t0 += t1 >> 29;
     t1 = ((sp_int64)a[ 0]) * b[ 3]
        + ((sp_int64)a[ 1]) * b[ 2]
        + ((sp_int64)a[ 2]) * b[ 1]
        + ((sp_int64)a[ 3]) * b[ 0];
-    t[ 2] = t0 & 0x1fffffff; t1 += t0 >> 29;
+    t[ 2] = (sp_digit)(t0 & 0x1fffffff); t1 += t0 >> 29;
     t0 = ((sp_int64)a[ 0]) * b[ 4]
        + ((sp_int64)a[ 1]) * b[ 3]
        + ((sp_int64)a[ 2]) * b[ 2]
        + ((sp_int64)a[ 3]) * b[ 1]
        + ((sp_int64)a[ 4]) * b[ 0];
-    t[ 3] = t1 & 0x1fffffff; t0 += t1 >> 29;
+    t[ 3] = (sp_digit)(t1 & 0x1fffffff); t0 += t1 >> 29;
     t1 = ((sp_int64)a[ 0]) * b[ 5]
        + ((sp_int64)a[ 1]) * b[ 4]
        + ((sp_int64)a[ 2]) * b[ 3]
        + ((sp_int64)a[ 3]) * b[ 2]
        + ((sp_int64)a[ 4]) * b[ 1]
        + ((sp_int64)a[ 5]) * b[ 0];
-    t[ 4] = t0 & 0x1fffffff; t1 += t0 >> 29;
+    t[ 4] = (sp_digit)(t0 & 0x1fffffff); t1 += t0 >> 29;
     t0 = ((sp_int64)a[ 0]) * b[ 6]
        + ((sp_int64)a[ 1]) * b[ 5]
        + ((sp_int64)a[ 2]) * b[ 4]
@@ -269,7 +264,7 @@ SP_NOINLINE static void sp_256_mul_sm2_9(sp_digit* r, const sp_digit* a,
        + ((sp_int64)a[ 4]) * b[ 2]
        + ((sp_int64)a[ 5]) * b[ 1]
        + ((sp_int64)a[ 6]) * b[ 0];
-    t[ 5] = t1 & 0x1fffffff; t0 += t1 >> 29;
+    t[ 5] = (sp_digit)(t1 & 0x1fffffff); t0 += t1 >> 29;
     t1 = ((sp_int64)a[ 0]) * b[ 7]
        + ((sp_int64)a[ 1]) * b[ 6]
        + ((sp_int64)a[ 2]) * b[ 5]
@@ -278,7 +273,7 @@ SP_NOINLINE static void sp_256_mul_sm2_9(sp_digit* r, const sp_digit* a,
        + ((sp_int64)a[ 5]) * b[ 2]
        + ((sp_int64)a[ 6]) * b[ 1]
        + ((sp_int64)a[ 7]) * b[ 0];
-    t[ 6] = t0 & 0x1fffffff; t1 += t0 >> 29;
+    t[ 6] = (sp_digit)(t0 & 0x1fffffff); t1 += t0 >> 29;
     t0 = ((sp_int64)a[ 0]) * b[ 8]
        + ((sp_int64)a[ 1]) * b[ 7]
        + ((sp_int64)a[ 2]) * b[ 6]
@@ -288,7 +283,7 @@ SP_NOINLINE static void sp_256_mul_sm2_9(sp_digit* r, const sp_digit* a,
        + ((sp_int64)a[ 6]) * b[ 2]
        + ((sp_int64)a[ 7]) * b[ 1]
        + ((sp_int64)a[ 8]) * b[ 0];
-    t[ 7] = t1 & 0x1fffffff; t0 += t1 >> 29;
+    t[ 7] = (sp_digit)(t1 & 0x1fffffff); t0 += t1 >> 29;
     t1 = ((sp_int64)a[ 1]) * b[ 8]
        + ((sp_int64)a[ 2]) * b[ 7]
        + ((sp_int64)a[ 3]) * b[ 6]
@@ -297,7 +292,7 @@ SP_NOINLINE static void sp_256_mul_sm2_9(sp_digit* r, const sp_digit* a,
        + ((sp_int64)a[ 6]) * b[ 3]
        + ((sp_int64)a[ 7]) * b[ 2]
        + ((sp_int64)a[ 8]) * b[ 1];
-    t[ 8] = t0 & 0x1fffffff; t1 += t0 >> 29;
+    t[ 8] = (sp_digit)(t0 & 0x1fffffff); t1 += t0 >> 29;
     t0 = ((sp_int64)a[ 2]) * b[ 8]
        + ((sp_int64)a[ 3]) * b[ 7]
        + ((sp_int64)a[ 4]) * b[ 6]
@@ -305,35 +300,35 @@ SP_NOINLINE static void sp_256_mul_sm2_9(sp_digit* r, const sp_digit* a,
        + ((sp_int64)a[ 6]) * b[ 4]
        + ((sp_int64)a[ 7]) * b[ 3]
        + ((sp_int64)a[ 8]) * b[ 2];
-    r[ 9] = t1 & 0x1fffffff; t0 += t1 >> 29;
+    r[ 9] = (sp_digit)(t1 & 0x1fffffff); t0 += t1 >> 29;
     t1 = ((sp_int64)a[ 3]) * b[ 8]
        + ((sp_int64)a[ 4]) * b[ 7]
        + ((sp_int64)a[ 5]) * b[ 6]
        + ((sp_int64)a[ 6]) * b[ 5]
        + ((sp_int64)a[ 7]) * b[ 4]
        + ((sp_int64)a[ 8]) * b[ 3];
-    r[10] = t0 & 0x1fffffff; t1 += t0 >> 29;
+    r[10] = (sp_digit)(t0 & 0x1fffffff); t1 += t0 >> 29;
     t0 = ((sp_int64)a[ 4]) * b[ 8]
        + ((sp_int64)a[ 5]) * b[ 7]
        + ((sp_int64)a[ 6]) * b[ 6]
        + ((sp_int64)a[ 7]) * b[ 5]
        + ((sp_int64)a[ 8]) * b[ 4];
-    r[11] = t1 & 0x1fffffff; t0 += t1 >> 29;
+    r[11] = (sp_digit)(t1 & 0x1fffffff); t0 += t1 >> 29;
     t1 = ((sp_int64)a[ 5]) * b[ 8]
        + ((sp_int64)a[ 6]) * b[ 7]
        + ((sp_int64)a[ 7]) * b[ 6]
        + ((sp_int64)a[ 8]) * b[ 5];
-    r[12] = t0 & 0x1fffffff; t1 += t0 >> 29;
+    r[12] = (sp_digit)(t0 & 0x1fffffff); t1 += t0 >> 29;
     t0 = ((sp_int64)a[ 6]) * b[ 8]
        + ((sp_int64)a[ 7]) * b[ 7]
        + ((sp_int64)a[ 8]) * b[ 6];
-    r[13] = t1 & 0x1fffffff; t0 += t1 >> 29;
+    r[13] = (sp_digit)(t1 & 0x1fffffff); t0 += t1 >> 29;
     t1 = ((sp_int64)a[ 7]) * b[ 8]
        + ((sp_int64)a[ 8]) * b[ 7];
-    r[14] = t0 & 0x1fffffff; t1 += t0 >> 29;
+    r[14] = (sp_digit)(t0 & 0x1fffffff); t1 += t0 >> 29;
     t0 = ((sp_int64)a[ 8]) * b[ 8];
-    r[15] = t1 & 0x1fffffff; t0 += t1 >> 29;
-    r[16] = t0 & 0x1fffffff;
+    r[15] = (sp_digit)(t1 & 0x1fffffff); t0 += t1 >> 29;
+    r[16] = (sp_digit)(t0 & 0x1fffffff);
     r[17] = (sp_digit)(t0 >> 29);
     XMEMCPY(r, t, sizeof(t));
 }
@@ -395,66 +390,66 @@ SP_NOINLINE static void sp_256_sqr_sm2_9(sp_digit* r, const sp_digit* a)
 
     t0 =  ((sp_int64)a[ 0]) * a[ 0];
     t1 = (((sp_int64)a[ 0]) * a[ 1]) * 2;
-    t[ 0] = t0 & 0x1fffffff; t1 += t0 >> 29;
+    t[ 0] = (sp_digit)(t0 & 0x1fffffff); t1 += t0 >> 29;
     t0 = (((sp_int64)a[ 0]) * a[ 2]) * 2
        +  ((sp_int64)a[ 1]) * a[ 1];
-    t[ 1] = t1 & 0x1fffffff; t0 += t1 >> 29;
+    t[ 1] = (sp_digit)(t1 & 0x1fffffff); t0 += t1 >> 29;
     t1 = (((sp_int64)a[ 0]) * a[ 3]
        +  ((sp_int64)a[ 1]) * a[ 2]) * 2;
-    t[ 2] = t0 & 0x1fffffff; t1 += t0 >> 29;
+    t[ 2] = (sp_digit)(t0 & 0x1fffffff); t1 += t0 >> 29;
     t0 = (((sp_int64)a[ 0]) * a[ 4]
        +  ((sp_int64)a[ 1]) * a[ 3]) * 2
        +  ((sp_int64)a[ 2]) * a[ 2];
-    t[ 3] = t1 & 0x1fffffff; t0 += t1 >> 29;
+    t[ 3] = (sp_digit)(t1 & 0x1fffffff); t0 += t1 >> 29;
     t1 = (((sp_int64)a[ 0]) * a[ 5]
        +  ((sp_int64)a[ 1]) * a[ 4]
        +  ((sp_int64)a[ 2]) * a[ 3]) * 2;
-    t[ 4] = t0 & 0x1fffffff; t1 += t0 >> 29;
+    t[ 4] = (sp_digit)(t0 & 0x1fffffff); t1 += t0 >> 29;
     t0 = (((sp_int64)a[ 0]) * a[ 6]
        +  ((sp_int64)a[ 1]) * a[ 5]
        +  ((sp_int64)a[ 2]) * a[ 4]) * 2
        +  ((sp_int64)a[ 3]) * a[ 3];
-    t[ 5] = t1 & 0x1fffffff; t0 += t1 >> 29;
+    t[ 5] = (sp_digit)(t1 & 0x1fffffff); t0 += t1 >> 29;
     t1 = (((sp_int64)a[ 0]) * a[ 7]
        +  ((sp_int64)a[ 1]) * a[ 6]
        +  ((sp_int64)a[ 2]) * a[ 5]
        +  ((sp_int64)a[ 3]) * a[ 4]) * 2;
-    t[ 6] = t0 & 0x1fffffff; t1 += t0 >> 29;
+    t[ 6] = (sp_digit)(t0 & 0x1fffffff); t1 += t0 >> 29;
     t0 = (((sp_int64)a[ 0]) * a[ 8]
        +  ((sp_int64)a[ 1]) * a[ 7]
        +  ((sp_int64)a[ 2]) * a[ 6]
        +  ((sp_int64)a[ 3]) * a[ 5]) * 2
        +  ((sp_int64)a[ 4]) * a[ 4];
-    t[ 7] = t1 & 0x1fffffff; t0 += t1 >> 29;
+    t[ 7] = (sp_digit)(t1 & 0x1fffffff); t0 += t1 >> 29;
     t1 = (((sp_int64)a[ 1]) * a[ 8]
        +  ((sp_int64)a[ 2]) * a[ 7]
        +  ((sp_int64)a[ 3]) * a[ 6]
        +  ((sp_int64)a[ 4]) * a[ 5]) * 2;
-    t[ 8] = t0 & 0x1fffffff; t1 += t0 >> 29;
+    t[ 8] = (sp_digit)(t0 & 0x1fffffff); t1 += t0 >> 29;
     t0 = (((sp_int64)a[ 2]) * a[ 8]
        +  ((sp_int64)a[ 3]) * a[ 7]
        +  ((sp_int64)a[ 4]) * a[ 6]) * 2
        +  ((sp_int64)a[ 5]) * a[ 5];
-    r[ 9] = t1 & 0x1fffffff; t0 += t1 >> 29;
+    r[ 9] = (sp_digit)(t1 & 0x1fffffff); t0 += t1 >> 29;
     t1 = (((sp_int64)a[ 3]) * a[ 8]
        +  ((sp_int64)a[ 4]) * a[ 7]
        +  ((sp_int64)a[ 5]) * a[ 6]) * 2;
-    r[10] = t0 & 0x1fffffff; t1 += t0 >> 29;
+    r[10] = (sp_digit)(t0 & 0x1fffffff); t1 += t0 >> 29;
     t0 = (((sp_int64)a[ 4]) * a[ 8]
        +  ((sp_int64)a[ 5]) * a[ 7]) * 2
        +  ((sp_int64)a[ 6]) * a[ 6];
-    r[11] = t1 & 0x1fffffff; t0 += t1 >> 29;
+    r[11] = (sp_digit)(t1 & 0x1fffffff); t0 += t1 >> 29;
     t1 = (((sp_int64)a[ 5]) * a[ 8]
        +  ((sp_int64)a[ 6]) * a[ 7]) * 2;
-    r[12] = t0 & 0x1fffffff; t1 += t0 >> 29;
+    r[12] = (sp_digit)(t0 & 0x1fffffff); t1 += t0 >> 29;
     t0 = (((sp_int64)a[ 6]) * a[ 8]) * 2
        +  ((sp_int64)a[ 7]) * a[ 7];
-    r[13] = t1 & 0x1fffffff; t0 += t1 >> 29;
+    r[13] = (sp_digit)(t1 & 0x1fffffff); t0 += t1 >> 29;
     t1 = (((sp_int64)a[ 7]) * a[ 8]) * 2;
-    r[14] = t0 & 0x1fffffff; t1 += t0 >> 29;
+    r[14] = (sp_digit)(t0 & 0x1fffffff); t1 += t0 >> 29;
     t0 =  ((sp_int64)a[ 8]) * a[ 8];
-    r[15] = t1 & 0x1fffffff; t0 += t1 >> 29;
-    r[16] = t0 & 0x1fffffff;
+    r[15] = (sp_digit)(t1 & 0x1fffffff); t0 += t1 >> 29;
+    r[16] = (sp_digit)(t0 & 0x1fffffff);
     r[17] = (sp_digit)(t0 >> 29);
     XMEMCPY(r, t, sizeof(t));
 }
@@ -836,17 +831,17 @@ SP_NOINLINE static void sp_256_mul_add_sm2_9(sp_digit* r, const sp_digit* a,
         t[1]  = (tb * a[i+1]) + r[i+1];
         t[2]  = (tb * a[i+2]) + r[i+2];
         t[3]  = (tb * a[i+3]) + r[i+3];
-        r[i+0] = t[0] & 0x1fffffff;
+        r[i+0] = (sp_digit)(t[0] & 0x1fffffff);
         t[1] += t[0] >> 29;
-        r[i+1] = t[1] & 0x1fffffff;
+        r[i+1] = (sp_digit)(t[1] & 0x1fffffff);
         t[2] += t[1] >> 29;
-        r[i+2] = t[2] & 0x1fffffff;
+        r[i+2] = (sp_digit)(t[2] & 0x1fffffff);
         t[3] += t[2] >> 29;
-        r[i+3] = t[3] & 0x1fffffff;
+        r[i+3] = (sp_digit)(t[3] & 0x1fffffff);
         t[0]  = t[3] >> 29;
     }
     t[0] += (tb * a[8]) + r[8];
-    r[8] = t[0] & 0x1fffffff;
+    r[8] = (sp_digit)(t[0] & 0x1fffffff);
     r[9] +=  (sp_digit)(t[0] >> 29);
 #else
     sp_int64 tb = b;
@@ -863,25 +858,25 @@ SP_NOINLINE static void sp_256_mul_add_sm2_9(sp_digit* r, const sp_digit* a,
         t[5]  = (tb * a[i+5]) + r[i+5];
         t[6]  = (tb * a[i+6]) + r[i+6];
         t[7]  = (tb * a[i+7]) + r[i+7];
-        r[i+0] = t[0] & 0x1fffffff;
+        r[i+0] = (sp_digit)(t[0] & 0x1fffffff);
         t[1] += t[0] >> 29;
-        r[i+1] = t[1] & 0x1fffffff;
+        r[i+1] = (sp_digit)(t[1] & 0x1fffffff);
         t[2] += t[1] >> 29;
-        r[i+2] = t[2] & 0x1fffffff;
+        r[i+2] = (sp_digit)(t[2] & 0x1fffffff);
         t[3] += t[2] >> 29;
-        r[i+3] = t[3] & 0x1fffffff;
+        r[i+3] = (sp_digit)(t[3] & 0x1fffffff);
         t[4] += t[3] >> 29;
-        r[i+4] = t[4] & 0x1fffffff;
+        r[i+4] = (sp_digit)(t[4] & 0x1fffffff);
         t[5] += t[4] >> 29;
-        r[i+5] = t[5] & 0x1fffffff;
+        r[i+5] = (sp_digit)(t[5] & 0x1fffffff);
         t[6] += t[5] >> 29;
-        r[i+6] = t[6] & 0x1fffffff;
+        r[i+6] = (sp_digit)(t[6] & 0x1fffffff);
         t[7] += t[6] >> 29;
-        r[i+7] = t[7] & 0x1fffffff;
+        r[i+7] = (sp_digit)(t[7] & 0x1fffffff);
         t[0]  = t[7] >> 29;
     }
     t[0] += (tb * a[8]) + r[8];
-    r[8] = t[0] & 0x1fffffff;
+    r[8] = (sp_digit)(t[0] & 0x1fffffff);
     r[9] +=  (sp_digit)(t[0] >> 29);
 #endif /* WOLFSSL_SP_SMALL */
 #endif /* !WOLFSSL_SP_LARGE_CODE */
@@ -924,7 +919,7 @@ static void sp_256_mont_shift_9(sp_digit* r, const sp_digit* a)
     n += ((sp_int64)a[9]) << 5;
 
     for (i = 0; i < 8; i++) {
-        r[i] = n & 0x1fffffff;
+        r[i] = (sp_digit)(n & 0x1fffffff);
         n >>= 29;
         n += ((sp_int64)a[10 + i]) << 5;
     }
@@ -932,14 +927,14 @@ static void sp_256_mont_shift_9(sp_digit* r, const sp_digit* a)
 #else
     sp_int64 n = a[8] >> 24;
     n += ((sp_int64)a[9]) << 5;
-    r[ 0] = n & 0x1fffffff; n >>= 29; n += ((sp_int64)a[10]) << 5;
-    r[ 1] = n & 0x1fffffff; n >>= 29; n += ((sp_int64)a[11]) << 5;
-    r[ 2] = n & 0x1fffffff; n >>= 29; n += ((sp_int64)a[12]) << 5;
-    r[ 3] = n & 0x1fffffff; n >>= 29; n += ((sp_int64)a[13]) << 5;
-    r[ 4] = n & 0x1fffffff; n >>= 29; n += ((sp_int64)a[14]) << 5;
-    r[ 5] = n & 0x1fffffff; n >>= 29; n += ((sp_int64)a[15]) << 5;
-    r[ 6] = n & 0x1fffffff; n >>= 29; n += ((sp_int64)a[16]) << 5;
-    r[ 7] = n & 0x1fffffff; n >>= 29; n += ((sp_int64)a[17]) << 5;
+    r[ 0] = (sp_digit)(n & 0x1fffffff); n >>= 29; n += ((sp_int64)a[10]) << 5;
+    r[ 1] = (sp_digit)(n & 0x1fffffff); n >>= 29; n += ((sp_int64)a[11]) << 5;
+    r[ 2] = (sp_digit)(n & 0x1fffffff); n >>= 29; n += ((sp_int64)a[12]) << 5;
+    r[ 3] = (sp_digit)(n & 0x1fffffff); n >>= 29; n += ((sp_int64)a[13]) << 5;
+    r[ 4] = (sp_digit)(n & 0x1fffffff); n >>= 29; n += ((sp_int64)a[14]) << 5;
+    r[ 5] = (sp_digit)(n & 0x1fffffff); n >>= 29; n += ((sp_int64)a[15]) << 5;
+    r[ 6] = (sp_digit)(n & 0x1fffffff); n >>= 29; n += ((sp_int64)a[16]) << 5;
+    r[ 7] = (sp_digit)(n & 0x1fffffff); n >>= 29; n += ((sp_int64)a[17]) << 5;
     r[8] = (sp_digit)n;
 #endif /* WOLFSSL_SP_SMALL */
     XMEMSET(&r[9], 0, sizeof(*r) * 9U);
@@ -1291,17 +1286,17 @@ SP_NOINLINE static void sp_256_rshift1_sm2_9(sp_digit* r, const sp_digit* a)
     int i;
 
     for (i=0; i<8; i++) {
-        r[i] = (a[i] >> 1) + ((a[i + 1] << 28) & 0x1fffffff);
+        r[i] = (a[i] >> 1) + (sp_digit)((a[i + 1] << 28) & 0x1fffffff);
     }
 #else
-    r[0] = (a[0] >> 1) + ((a[1] << 28) & 0x1fffffff);
-    r[1] = (a[1] >> 1) + ((a[2] << 28) & 0x1fffffff);
-    r[2] = (a[2] >> 1) + ((a[3] << 28) & 0x1fffffff);
-    r[3] = (a[3] >> 1) + ((a[4] << 28) & 0x1fffffff);
-    r[4] = (a[4] >> 1) + ((a[5] << 28) & 0x1fffffff);
-    r[5] = (a[5] >> 1) + ((a[6] << 28) & 0x1fffffff);
-    r[6] = (a[6] >> 1) + ((a[7] << 28) & 0x1fffffff);
-    r[7] = (a[7] >> 1) + ((a[8] << 28) & 0x1fffffff);
+    r[0] = (a[0] >> 1) + (sp_digit)((a[1] << 28) & 0x1fffffff);
+    r[1] = (a[1] >> 1) + (sp_digit)((a[2] << 28) & 0x1fffffff);
+    r[2] = (a[2] >> 1) + (sp_digit)((a[3] << 28) & 0x1fffffff);
+    r[3] = (a[3] >> 1) + (sp_digit)((a[4] << 28) & 0x1fffffff);
+    r[4] = (a[4] >> 1) + (sp_digit)((a[5] << 28) & 0x1fffffff);
+    r[5] = (a[5] >> 1) + (sp_digit)((a[6] << 28) & 0x1fffffff);
+    r[6] = (a[6] >> 1) + (sp_digit)((a[7] << 28) & 0x1fffffff);
+    r[7] = (a[7] >> 1) + (sp_digit)((a[8] << 28) & 0x1fffffff);
 #endif
     r[8] = a[8] >> 1;
 }
@@ -1951,18 +1946,18 @@ SP_NOINLINE static void sp_256_rshift_sm2_9(sp_digit* r, const sp_digit* a,
 
 #ifdef WOLFSSL_SP_SMALL
     for (i=0; i<8; i++) {
-        r[i] = ((a[i] >> n) | (a[i + 1] << (29 - n))) & 0x1fffffff;
+        r[i] = (sp_digit)(((a[i] >> n) | (a[i + 1] << (29 - n))) & 0x1fffffff);
     }
 #else
     for (i=0; i<8; i += 8) {
-        r[i+0] = (a[i+0] >> n) | ((a[i+1] << (29 - n)) & 0x1fffffff);
-        r[i+1] = (a[i+1] >> n) | ((a[i+2] << (29 - n)) & 0x1fffffff);
-        r[i+2] = (a[i+2] >> n) | ((a[i+3] << (29 - n)) & 0x1fffffff);
-        r[i+3] = (a[i+3] >> n) | ((a[i+4] << (29 - n)) & 0x1fffffff);
-        r[i+4] = (a[i+4] >> n) | ((a[i+5] << (29 - n)) & 0x1fffffff);
-        r[i+5] = (a[i+5] >> n) | ((a[i+6] << (29 - n)) & 0x1fffffff);
-        r[i+6] = (a[i+6] >> n) | ((a[i+7] << (29 - n)) & 0x1fffffff);
-        r[i+7] = (a[i+7] >> n) | ((a[i+8] << (29 - n)) & 0x1fffffff);
+        r[i+0] = (a[i+0] >> n) | (sp_digit)((a[i+1] << (29 - n)) & 0x1fffffff);
+        r[i+1] = (a[i+1] >> n) | (sp_digit)((a[i+2] << (29 - n)) & 0x1fffffff);
+        r[i+2] = (a[i+2] >> n) | (sp_digit)((a[i+3] << (29 - n)) & 0x1fffffff);
+        r[i+3] = (a[i+3] >> n) | (sp_digit)((a[i+4] << (29 - n)) & 0x1fffffff);
+        r[i+4] = (a[i+4] >> n) | (sp_digit)((a[i+5] << (29 - n)) & 0x1fffffff);
+        r[i+5] = (a[i+5] >> n) | (sp_digit)((a[i+6] << (29 - n)) & 0x1fffffff);
+        r[i+6] = (a[i+6] >> n) | (sp_digit)((a[i+7] << (29 - n)) & 0x1fffffff);
+        r[i+7] = (a[i+7] >> n) | (sp_digit)((a[i+8] << (29 - n)) & 0x1fffffff);
     }
 #endif /* WOLFSSL_SP_SMALL */
     r[8] = a[8] >> n;
@@ -2699,13 +2694,13 @@ static void sp_256_proj_point_add_sub_sm2_9(sp_point_256* ra,
 /* Structure used to describe recoding of scalar multiplication. */
 typedef struct ecc_recode_256 {
     /* Index into pre-computation table. */
-    uint8_t i;
+    word8 i;
     /* Use the negative of the point. */
-    uint8_t neg;
+    word8 neg;
 } ecc_recode_256;
 
 /* The index into pre-computation table to use. */
-static const uint8_t recode_index_9_6[66] = {
+static const word8 recode_index_9_6[66] = {
      0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15,
     16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
     32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17,
@@ -2714,7 +2709,7 @@ static const uint8_t recode_index_9_6[66] = {
 };
 
 /* Whether to negate y-ordinate. */
-static const uint8_t recode_neg_9_6[66] = {
+static const word8 recode_neg_9_6[66] = {
      0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
      0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
      1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
@@ -2732,7 +2727,7 @@ static void sp_256_ecc_recode_6_9(const sp_digit* k, ecc_recode_256* v)
 {
     int i;
     int j;
-    uint8_t y;
+    word8 y;
     int carry = 0;
     int o;
     sp_digit n;
@@ -2741,7 +2736,7 @@ static void sp_256_ecc_recode_6_9(const sp_digit* k, ecc_recode_256* v)
     n = k[j];
     o = 0;
     for (i=0; i<43; i++) {
-        y = (uint8_t)(int8_t)n;
+        y = (word8)(int8_t)n;
         if (o + 6 < 29) {
             y &= 0x3f;
             n >>= 6;
@@ -2755,12 +2750,12 @@ static void sp_256_ecc_recode_6_9(const sp_digit* k, ecc_recode_256* v)
         }
         else if (++j < 9) {
             n = k[j];
-            y |= (uint8_t)((n << (29 - o)) & 0x3f);
+            y |= (word8)((n << (29 - o)) & 0x3f);
             o -= 23;
             n >>= o;
         }
 
-        y += (uint8_t)carry;
+        y = (word8)(y + carry);
         v[i].i = recode_index_9_6[y];
         v[i].neg = recode_neg_9_6[y];
         carry = (y >> 6) + v[i].neg;
@@ -3360,7 +3355,7 @@ typedef struct sp_cache_256_t {
     /* Precomputation table for point. */
     sp_table_entry_256 table[256];
     /* Count of entries in table. */
-    uint32_t cnt;
+    word32 cnt;
     /* Point and table set in entry. */
     int set;
 } sp_cache_256_t;
@@ -3388,7 +3383,7 @@ static void sp_ecc_get_cache_256(const sp_point_256* g, sp_cache_256_t** cache)
 {
     int i;
     int j;
-    uint32_t least;
+    word32 least;
 
     if (sp_cache_256_inited == 0) {
         for (i=0; i<FP_ENTRIES; i++) {
@@ -6419,7 +6414,7 @@ int sp_ecc_map_sm2_256(mp_int* pX, mp_int* pY, mp_int* pZ)
 #endif /* WOLFSSL_PUBLIC_ECC_ADD_DBL */
 #ifdef HAVE_COMP_KEY
 /* Square root power for the P256 curve. */
-static const uint32_t p256_sm2_sqrt_power[8] = {
+static const word32 p256_sm2_sqrt_power[8] = {
     0x00000000,0x40000000,0xc0000000,0xffffffff,0xffffffff,0xffffffff,
     0xbfffffff,0x3fffffff
 };

--- a/sp_sm2_c64.c
+++ b/sp_sm2_c64.c
@@ -1,6 +1,6 @@
 /* sp.c
  *
- * Copyright (C) 2006-2024 wolfSSL Inc.
+ * Copyright (C) 2006-2025 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *
@@ -21,16 +21,11 @@
 
 /* Implementation by Sean Parkinson. */
 
-#ifdef HAVE_CONFIG_H
-    #include <config.h>
-#endif
-
-#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 
 #if defined(WOLFSSL_HAVE_SP_RSA) || defined(WOLFSSL_HAVE_SP_DH) || \
     defined(WOLFSSL_HAVE_SP_ECC)
 
-#include <wolfssl/wolfcrypt/error-crypt.h>
 #include <wolfssl/wolfcrypt/cpuid.h>
 #ifdef NO_INLINE
     #include <wolfssl/wolfcrypt/misc.h>
@@ -255,16 +250,16 @@ SP_NOINLINE static void sp_256_mul_sm2_5(sp_digit* r, const sp_digit* a,
                  + ((sp_int128)a[ 4]) * b[ 3];
     sp_int128 t8   = ((sp_int128)a[ 4]) * b[ 4];
 
-    t1   += t0  >> 52; r[ 0] = t0  & 0xfffffffffffffL;
-    t2   += t1  >> 52; r[ 1] = t1  & 0xfffffffffffffL;
-    t3   += t2  >> 52; r[ 2] = t2  & 0xfffffffffffffL;
-    t4   += t3  >> 52; r[ 3] = t3  & 0xfffffffffffffL;
-    t5   += t4  >> 52; r[ 4] = t4  & 0xfffffffffffffL;
-    t6   += t5  >> 52; r[ 5] = t5  & 0xfffffffffffffL;
-    t7   += t6  >> 52; r[ 6] = t6  & 0xfffffffffffffL;
-    t8   += t7  >> 52; r[ 7] = t7  & 0xfffffffffffffL;
+    t1   += t0  >> 52; r[ 0] = (sp_digit)(t0  & 0xfffffffffffffL);
+    t2   += t1  >> 52; r[ 1] = (sp_digit)(t1  & 0xfffffffffffffL);
+    t3   += t2  >> 52; r[ 2] = (sp_digit)(t2  & 0xfffffffffffffL);
+    t4   += t3  >> 52; r[ 3] = (sp_digit)(t3  & 0xfffffffffffffL);
+    t5   += t4  >> 52; r[ 4] = (sp_digit)(t4  & 0xfffffffffffffL);
+    t6   += t5  >> 52; r[ 5] = (sp_digit)(t5  & 0xfffffffffffffL);
+    t7   += t6  >> 52; r[ 6] = (sp_digit)(t6  & 0xfffffffffffffL);
+    t8   += t7  >> 52; r[ 7] = (sp_digit)(t7  & 0xfffffffffffffL);
     r[9] = (sp_digit)(t8 >> 52);
-                       r[8] = t8 & 0xfffffffffffffL;
+                       r[8] = (sp_digit)(t8 & 0xfffffffffffffL);
 }
 
 #endif /* WOLFSSL_SP_SMALL */
@@ -334,16 +329,16 @@ SP_NOINLINE static void sp_256_sqr_sm2_5(sp_digit* r, const sp_digit* a)
     sp_int128 t7   = (((sp_int128)a[ 3]) * a[ 4]) * 2;
     sp_int128 t8   =  ((sp_int128)a[ 4]) * a[ 4];
 
-    t1   += t0  >> 52; r[ 0] = t0  & 0xfffffffffffffL;
-    t2   += t1  >> 52; r[ 1] = t1  & 0xfffffffffffffL;
-    t3   += t2  >> 52; r[ 2] = t2  & 0xfffffffffffffL;
-    t4   += t3  >> 52; r[ 3] = t3  & 0xfffffffffffffL;
-    t5   += t4  >> 52; r[ 4] = t4  & 0xfffffffffffffL;
-    t6   += t5  >> 52; r[ 5] = t5  & 0xfffffffffffffL;
-    t7   += t6  >> 52; r[ 6] = t6  & 0xfffffffffffffL;
-    t8   += t7  >> 52; r[ 7] = t7  & 0xfffffffffffffL;
+    t1   += t0  >> 52; r[ 0] = (sp_digit)(t0  & 0xfffffffffffffL);
+    t2   += t1  >> 52; r[ 1] = (sp_digit)(t1  & 0xfffffffffffffL);
+    t3   += t2  >> 52; r[ 2] = (sp_digit)(t2  & 0xfffffffffffffL);
+    t4   += t3  >> 52; r[ 3] = (sp_digit)(t3  & 0xfffffffffffffL);
+    t5   += t4  >> 52; r[ 4] = (sp_digit)(t4  & 0xfffffffffffffL);
+    t6   += t5  >> 52; r[ 5] = (sp_digit)(t5  & 0xfffffffffffffL);
+    t7   += t6  >> 52; r[ 6] = (sp_digit)(t6  & 0xfffffffffffffL);
+    t8   += t7  >> 52; r[ 7] = (sp_digit)(t7  & 0xfffffffffffffL);
     r[9] = (sp_digit)(t8 >> 52);
-                       r[8] = t8 & 0xfffffffffffffL;
+                       r[8] = (sp_digit)(t8 & 0xfffffffffffffL);
 }
 
 #endif /* WOLFSSL_SP_SMALL */
@@ -694,17 +689,17 @@ SP_NOINLINE static void sp_256_mul_add_sm2_5(sp_digit* r, const sp_digit* a,
         t[1]  = (tb * a[i+1]) + r[i+1];
         t[2]  = (tb * a[i+2]) + r[i+2];
         t[3]  = (tb * a[i+3]) + r[i+3];
-        r[i+0] = t[0] & 0xfffffffffffffL;
+        r[i+0] = (sp_digit)(t[0] & 0xfffffffffffffL);
         t[1] += t[0] >> 52;
-        r[i+1] = t[1] & 0xfffffffffffffL;
+        r[i+1] = (sp_digit)(t[1] & 0xfffffffffffffL);
         t[2] += t[1] >> 52;
-        r[i+2] = t[2] & 0xfffffffffffffL;
+        r[i+2] = (sp_digit)(t[2] & 0xfffffffffffffL);
         t[3] += t[2] >> 52;
-        r[i+3] = t[3] & 0xfffffffffffffL;
+        r[i+3] = (sp_digit)(t[3] & 0xfffffffffffffL);
         t[0]  = t[3] >> 52;
     }
     t[0] += (tb * a[4]) + r[4];
-    r[4] = t[0] & 0xfffffffffffffL;
+    r[4] = (sp_digit)(t[0] & 0xfffffffffffffL);
     r[5] +=  (sp_digit)(t[0] >> 52);
 #else
     sp_int128 tb = b;
@@ -758,7 +753,7 @@ static void sp_256_mont_shift_5(sp_digit* r, const sp_digit* a)
     n = a[4] >> 48;
     for (i = 0; i < 4; i++) {
         n += (sp_uint64)a[5 + i] << 4;
-        r[i] = n & 0xfffffffffffffL;
+        r[i] = (sp_digit)(n & 0xfffffffffffffL);
         n >>= 52;
     }
     n += (sp_uint64)a[9] << 4;
@@ -767,10 +762,10 @@ static void sp_256_mont_shift_5(sp_digit* r, const sp_digit* a)
     sp_uint64 n;
 
     n  = a[4] >> 48;
-    n += (sp_uint64)a[ 5] << 4U; r[ 0] = n & 0xfffffffffffffUL; n >>= 52U;
-    n += (sp_uint64)a[ 6] << 4U; r[ 1] = n & 0xfffffffffffffUL; n >>= 52U;
-    n += (sp_uint64)a[ 7] << 4U; r[ 2] = n & 0xfffffffffffffUL; n >>= 52U;
-    n += (sp_uint64)a[ 8] << 4U; r[ 3] = n & 0xfffffffffffffUL; n >>= 52U;
+    n += (sp_uint64)a[ 5] << 4U; r[ 0] = (sp_digit)(n & 0xfffffffffffffUL); n >>= 52U;
+    n += (sp_uint64)a[ 6] << 4U; r[ 1] = (sp_digit)(n & 0xfffffffffffffUL); n >>= 52U;
+    n += (sp_uint64)a[ 7] << 4U; r[ 2] = (sp_digit)(n & 0xfffffffffffffUL); n >>= 52U;
+    n += (sp_uint64)a[ 8] << 4U; r[ 3] = (sp_digit)(n & 0xfffffffffffffUL); n >>= 52U;
     n += (sp_uint64)a[ 9] << 4U; r[ 4] = n;
 #endif /* WOLFSSL_SP_SMALL */
     XMEMSET(&r[5], 0, sizeof(*r) * 5U);
@@ -1118,13 +1113,13 @@ SP_NOINLINE static void sp_256_rshift1_sm2_5(sp_digit* r, const sp_digit* a)
     int i;
 
     for (i=0; i<4; i++) {
-        r[i] = (a[i] >> 1) + ((a[i + 1] << 51) & 0xfffffffffffffL);
+        r[i] = (a[i] >> 1) + (sp_digit)((a[i + 1] << 51) & 0xfffffffffffffL);
     }
 #else
-    r[0] = (a[0] >> 1) + ((a[1] << 51) & 0xfffffffffffffL);
-    r[1] = (a[1] >> 1) + ((a[2] << 51) & 0xfffffffffffffL);
-    r[2] = (a[2] >> 1) + ((a[3] << 51) & 0xfffffffffffffL);
-    r[3] = (a[3] >> 1) + ((a[4] << 51) & 0xfffffffffffffL);
+    r[0] = (a[0] >> 1) + (sp_digit)((a[1] << 51) & 0xfffffffffffffL);
+    r[1] = (a[1] >> 1) + (sp_digit)((a[2] << 51) & 0xfffffffffffffL);
+    r[2] = (a[2] >> 1) + (sp_digit)((a[3] << 51) & 0xfffffffffffffL);
+    r[3] = (a[3] >> 1) + (sp_digit)((a[4] << 51) & 0xfffffffffffffL);
 #endif
     r[4] = a[4] >> 1;
 }
@@ -1753,23 +1748,23 @@ SP_NOINLINE static void sp_256_rshift_sm2_5(sp_digit* r, const sp_digit* a,
 
 #ifdef WOLFSSL_SP_SMALL
     for (i=0; i<4; i++) {
-        r[i] = ((a[i] >> n) | (a[i + 1] << (52 - n))) & 0xfffffffffffffL;
+        r[i] = (sp_digit)(((a[i] >> n) | (a[i + 1] << (52 - n))) & 0xfffffffffffffL);
     }
 #else
     for (i=0; i<0; i += 8) {
-        r[i+0] = (a[i+0] >> n) | ((a[i+1] << (52 - n)) & 0xfffffffffffffL);
-        r[i+1] = (a[i+1] >> n) | ((a[i+2] << (52 - n)) & 0xfffffffffffffL);
-        r[i+2] = (a[i+2] >> n) | ((a[i+3] << (52 - n)) & 0xfffffffffffffL);
-        r[i+3] = (a[i+3] >> n) | ((a[i+4] << (52 - n)) & 0xfffffffffffffL);
-        r[i+4] = (a[i+4] >> n) | ((a[i+5] << (52 - n)) & 0xfffffffffffffL);
-        r[i+5] = (a[i+5] >> n) | ((a[i+6] << (52 - n)) & 0xfffffffffffffL);
-        r[i+6] = (a[i+6] >> n) | ((a[i+7] << (52 - n)) & 0xfffffffffffffL);
-        r[i+7] = (a[i+7] >> n) | ((a[i+8] << (52 - n)) & 0xfffffffffffffL);
+        r[i+0] = (a[i+0] >> n) | (sp_digit)((a[i+1] << (52 - n)) & 0xfffffffffffffL);
+        r[i+1] = (a[i+1] >> n) | (sp_digit)((a[i+2] << (52 - n)) & 0xfffffffffffffL);
+        r[i+2] = (a[i+2] >> n) | (sp_digit)((a[i+3] << (52 - n)) & 0xfffffffffffffL);
+        r[i+3] = (a[i+3] >> n) | (sp_digit)((a[i+4] << (52 - n)) & 0xfffffffffffffL);
+        r[i+4] = (a[i+4] >> n) | (sp_digit)((a[i+5] << (52 - n)) & 0xfffffffffffffL);
+        r[i+5] = (a[i+5] >> n) | (sp_digit)((a[i+6] << (52 - n)) & 0xfffffffffffffL);
+        r[i+6] = (a[i+6] >> n) | (sp_digit)((a[i+7] << (52 - n)) & 0xfffffffffffffL);
+        r[i+7] = (a[i+7] >> n) | (sp_digit)((a[i+8] << (52 - n)) & 0xfffffffffffffL);
     }
-    r[0] = (a[0] >> n) | ((a[1] << (52 - n)) & 0xfffffffffffffL);
-    r[1] = (a[1] >> n) | ((a[2] << (52 - n)) & 0xfffffffffffffL);
-    r[2] = (a[2] >> n) | ((a[3] << (52 - n)) & 0xfffffffffffffL);
-    r[3] = (a[3] >> n) | ((a[4] << (52 - n)) & 0xfffffffffffffL);
+    r[0] = (a[0] >> n) | (sp_digit)((a[1] << (52 - n)) & 0xfffffffffffffL);
+    r[1] = (a[1] >> n) | (sp_digit)((a[2] << (52 - n)) & 0xfffffffffffffL);
+    r[2] = (a[2] >> n) | (sp_digit)((a[3] << (52 - n)) & 0xfffffffffffffL);
+    r[3] = (a[3] >> n) | (sp_digit)((a[4] << (52 - n)) & 0xfffffffffffffL);
 #endif /* WOLFSSL_SP_SMALL */
     r[4] = a[4] >> n;
 }
@@ -2497,13 +2492,13 @@ static void sp_256_proj_point_add_sub_sm2_5(sp_point_256* ra,
 /* Structure used to describe recoding of scalar multiplication. */
 typedef struct ecc_recode_256 {
     /* Index into pre-computation table. */
-    uint8_t i;
+    word8 i;
     /* Use the negative of the point. */
-    uint8_t neg;
+    word8 neg;
 } ecc_recode_256;
 
 /* The index into pre-computation table to use. */
-static const uint8_t recode_index_5_6[66] = {
+static const word8 recode_index_5_6[66] = {
      0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15,
     16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
     32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17,
@@ -2512,7 +2507,7 @@ static const uint8_t recode_index_5_6[66] = {
 };
 
 /* Whether to negate y-ordinate. */
-static const uint8_t recode_neg_5_6[66] = {
+static const word8 recode_neg_5_6[66] = {
      0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
      0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
      1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
@@ -2530,7 +2525,7 @@ static void sp_256_ecc_recode_6_5(const sp_digit* k, ecc_recode_256* v)
 {
     int i;
     int j;
-    uint8_t y;
+    word8 y;
     int carry = 0;
     int o;
     sp_digit n;
@@ -2539,7 +2534,7 @@ static void sp_256_ecc_recode_6_5(const sp_digit* k, ecc_recode_256* v)
     n = k[j];
     o = 0;
     for (i=0; i<43; i++) {
-        y = (uint8_t)(int8_t)n;
+        y = (word8)(int8_t)n;
         if (o + 6 < 52) {
             y &= 0x3f;
             n >>= 6;
@@ -2553,12 +2548,12 @@ static void sp_256_ecc_recode_6_5(const sp_digit* k, ecc_recode_256* v)
         }
         else if (++j < 5) {
             n = k[j];
-            y |= (uint8_t)((n << (52 - o)) & 0x3f);
+            y |= (word8)((n << (52 - o)) & 0x3f);
             o -= 46;
             n >>= o;
         }
 
-        y += (uint8_t)carry;
+        y = (word8)(y + carry);
         v[i].i = recode_index_5_6[y];
         v[i].neg = recode_neg_5_6[y];
         carry = (y >> 6) + v[i].neg;
@@ -3118,7 +3113,7 @@ typedef struct sp_cache_256_t {
     /* Precomputation table for point. */
     sp_table_entry_256 table[256];
     /* Count of entries in table. */
-    uint32_t cnt;
+    word32 cnt;
     /* Point and table set in entry. */
     int set;
 } sp_cache_256_t;
@@ -3146,7 +3141,7 @@ static void sp_ecc_get_cache_256(const sp_point_256* g, sp_cache_256_t** cache)
 {
     int i;
     int j;
-    uint32_t least;
+    word32 least;
 
     if (sp_cache_256_inited == 0) {
         for (i=0; i<FP_ENTRIES; i++) {
@@ -6173,7 +6168,7 @@ int sp_ecc_map_sm2_256(mp_int* pX, mp_int* pY, mp_int* pZ)
 #endif /* WOLFSSL_PUBLIC_ECC_ADD_DBL */
 #ifdef HAVE_COMP_KEY
 /* Square root power for the P256 curve. */
-static const uint64_t p256_sm2_sqrt_power[4] = {
+static const word64 p256_sm2_sqrt_power[4] = {
     0x4000000000000000,0xffffffffc0000000,0xffffffffffffffff,
     0x3fffffffbfffffff
 };

--- a/sp_sm2_cortexm.c
+++ b/sp_sm2_cortexm.c
@@ -1,6 +1,6 @@
 /* sp.c
  *
- * Copyright (C) 2006-2024 wolfSSL Inc.
+ * Copyright (C) 2006-2025 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *
@@ -21,16 +21,11 @@
 
 /* Implementation by Sean Parkinson. */
 
-#ifdef HAVE_CONFIG_H
-    #include <config.h>
-#endif
-
-#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 
 #if defined(WOLFSSL_HAVE_SP_RSA) || defined(WOLFSSL_HAVE_SP_DH) || \
     defined(WOLFSSL_HAVE_SP_ECC)
 
-#include <wolfssl/wolfcrypt/error-crypt.h>
 #include <wolfssl/wolfcrypt/cpuid.h>
 #ifdef NO_INLINE
     #include <wolfssl/wolfcrypt/misc.h>
@@ -170,7 +165,8 @@ static const sp_digit p256_sm2_b[8] = {
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_256_mul_sm2_8(sp_digit* r_p, const sp_digit* a_p, const sp_digit* b_p)
+static void sp_256_mul_sm2_8(sp_digit* r_p, const sp_digit* a_p,
+    const sp_digit* b_p)
 #else
 static void sp_256_mul_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
@@ -284,7 +280,8 @@ static void sp_256_mul_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit* b)
 #endif
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
         :
-        : "memory", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "lr", "r11", "cc"
+        : "memory", "cc", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "lr",
+            "r11"
     );
 }
 
@@ -297,9 +294,11 @@ static void sp_256_mul_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit* b)
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_256_mul_sm2_8(sp_digit* r_p, const sp_digit* a_p, const sp_digit* b_p)
+SP_NOINLINE static void sp_256_mul_sm2_8(sp_digit* r_p, const sp_digit* a_p,
+    const sp_digit* b_p)
 #else
-SP_NOINLINE static void sp_256_mul_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit* b)
+SP_NOINLINE static void sp_256_mul_sm2_8(sp_digit* r, const sp_digit* a,
+    const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -638,13 +637,14 @@ SP_NOINLINE static void sp_256_mul_sm2_8(sp_digit* r, const sp_digit* a, const s
         "LDR	%[r], [sp, #32]\n\t"
         "ADD	%[r], %[r], #0x20\n\t"
         "STM	%[r], {r3, r4, r5, r6, r7, r8, r9, r10}\n\t"
-        "LDM	sp, {r3, r4, r5, r6, r7, r8, r9, r10}\n\t"
+        "ldm   sp, {r3, r4, r5, r6, r7, r8, r9, r10}\n\t"
         "SUB	%[r], %[r], #0x20\n\t"
         "STM	%[r], {r3, r4, r5, r6, r7, r8, r9, r10}\n\t"
         "ADD	sp, sp, #0x24\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
         :
-        : "memory", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12", "lr", "cc"
+        : "memory", "cc", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10",
+            "r11", "r12", "lr"
     );
 }
 
@@ -656,9 +656,11 @@ SP_NOINLINE static void sp_256_mul_sm2_8(sp_digit* r, const sp_digit* a, const s
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_256_mul_sm2_8(sp_digit* r_p, const sp_digit* a_p, const sp_digit* b_p)
+SP_NOINLINE static void sp_256_mul_sm2_8(sp_digit* r_p, const sp_digit* a_p,
+    const sp_digit* b_p)
 #else
-SP_NOINLINE static void sp_256_mul_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit* b)
+SP_NOINLINE static void sp_256_mul_sm2_8(sp_digit* r, const sp_digit* a,
+    const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -676,8 +678,8 @@ SP_NOINLINE static void sp_256_mul_sm2_8(sp_digit* r, const sp_digit* a, const s
         "STR	%[a], [sp, #40]\n\t"
 #endif /* WOLFSSL_NO_VAR_ASSIGN_REG */
         "MOV	lr, %[b]\n\t"
-        "LDM	%[a], {r0, r1, r2, r3}\n\t"
-        "LDM	lr!, {r4, r5, r6}\n\t"
+        "ldm   %[a], {r0, r1, r2, r3}\n\t"
+        "ldm   lr!, {r4, r5, r6}\n\t"
         "UMULL	r10, r11, r0, r4\n\t"
         "UMULL	r12, r7, r1, r4\n\t"
         "UMAAL	r11, r12, r0, r5\n\t"
@@ -687,7 +689,7 @@ SP_NOINLINE static void sp_256_mul_sm2_8(sp_digit* r, const sp_digit* a, const s
         "UMAAL	r8, r9, r3, r4\n\t"
         "STM	sp, {r10, r11, r12}\n\t"
         "UMAAL	r7, r8, r2, r5\n\t"
-        "LDM	lr!, {r4}\n\t"
+        "ldm   lr!, {r4}\n\t"
         "UMULL	r10, r11, r1, r6\n\t"
         "UMAAL	r8, r9, r2, r6\n\t"
         "UMAAL	r7, r10, r0, r4\n\t"
@@ -697,7 +699,7 @@ SP_NOINLINE static void sp_256_mul_sm2_8(sp_digit* r, const sp_digit* a, const s
         "UMAAL	r9, r11, r3, r6\n\t"
         "UMAAL	r9, r10, r2, r4\n\t"
         "UMAAL	r10, r11, r3, r4\n\t"
-        "LDM	lr, {r4, r5, r6, r7}\n\t"
+        "ldm   lr, {r4, r5, r6, r7}\n\t"
         "MOV	r12, #0x0\n\t"
         "UMLAL	r8, r12, r0, r4\n\t"
         "UMAAL	r9, r12, r1, r4\n\t"
@@ -721,48 +723,48 @@ SP_NOINLINE static void sp_256_mul_sm2_8(sp_digit* r, const sp_digit* a, const s
         "UMAAL	r4, r6, r2, r7\n\t"
         "SUB	lr, lr, #0x10\n\t"
         "UMAAL	r5, r6, r3, r7\n\t"
-        "LDM	r0, {r0, r1, r2, r3}\n\t"
+        "ldm   r0, {r0, r1, r2, r3}\n\t"
         "STR	r6, [sp, #32]\n\t"
-        "LDM	lr!, {r6}\n\t"
+        "ldm   lr!, {r6}\n\t"
         "MOV	r7, #0x0\n\t"
         "UMLAL	r8, r7, r0, r6\n\t"
         "UMAAL	r9, r7, r1, r6\n\t"
         "STR	r8, [sp, #16]\n\t"
         "UMAAL	r10, r7, r2, r6\n\t"
         "UMAAL	r11, r7, r3, r6\n\t"
-        "LDM	lr!, {r6}\n\t"
+        "ldm   lr!, {r6}\n\t"
         "MOV	r8, #0x0\n\t"
         "UMLAL	r9, r8, r0, r6\n\t"
         "UMAAL	r10, r8, r1, r6\n\t"
         "STR	r9, [sp, #20]\n\t"
         "UMAAL	r11, r8, r2, r6\n\t"
         "UMAAL	r12, r8, r3, r6\n\t"
-        "LDM	lr!, {r6}\n\t"
+        "ldm   lr!, {r6}\n\t"
         "MOV	r9, #0x0\n\t"
         "UMLAL	r10, r9, r0, r6\n\t"
         "UMAAL	r11, r9, r1, r6\n\t"
         "STR	r10, [sp, #24]\n\t"
         "UMAAL	r12, r9, r2, r6\n\t"
         "UMAAL	r4, r9, r3, r6\n\t"
-        "LDM	lr!, {r6}\n\t"
+        "ldm   lr!, {r6}\n\t"
         "MOV	r10, #0x0\n\t"
         "UMLAL	r11, r10, r0, r6\n\t"
         "UMAAL	r12, r10, r1, r6\n\t"
         "STR	r11, [sp, #28]\n\t"
         "UMAAL	r4, r10, r2, r6\n\t"
         "UMAAL	r5, r10, r3, r6\n\t"
-        "LDM	lr!, {r11}\n\t"
+        "ldm   lr!, {r11}\n\t"
         "UMAAL	r12, r7, r0, r11\n\t"
         "UMAAL	r4, r7, r1, r11\n\t"
         "LDR	r6, [sp, #32]\n\t"
         "UMAAL	r5, r7, r2, r11\n\t"
         "UMAAL	r6, r7, r3, r11\n\t"
-        "LDM	lr!, {r11}\n\t"
+        "ldm   lr!, {r11}\n\t"
         "UMAAL	r4, r8, r0, r11\n\t"
         "UMAAL	r5, r8, r1, r11\n\t"
         "UMAAL	r6, r8, r2, r11\n\t"
         "UMAAL	r7, r8, r3, r11\n\t"
-        "LDM	lr, {r11, lr}\n\t"
+        "ldm   lr, {r11, lr}\n\t"
         "UMAAL	r5, r9, r0, r11\n\t"
         "UMAAL	r6, r10, r0, lr\n\t"
         "UMAAL	r6, r9, r1, r11\n\t"
@@ -776,12 +778,13 @@ SP_NOINLINE static void sp_256_mul_sm2_8(sp_digit* r, const sp_digit* a, const s
         "ADD	lr, lr, #0x20\n\t"
         "STM	lr, {r3, r4, r5, r6, r7, r8, r9, r10}\n\t"
         "SUB	lr, lr, #0x20\n\t"
-        "LDM	sp, {r3, r4, r5, r6, r7, r8, r9, r10}\n\t"
+        "ldm   sp, {r3, r4, r5, r6, r7, r8, r9, r10}\n\t"
         "STM	lr, {r3, r4, r5, r6, r7, r8, r9, r10}\n\t"
         "ADD	sp, sp, #0x2c\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
         :
-        : "memory", "r3", "r4", "r5", "r6", "r10", "r11", "r12", "r7", "r8", "r9", "lr", "cc"
+        : "memory", "cc", "r3", "r4", "r5", "r6", "r10", "r11", "r12", "r7",
+            "r8", "r9", "lr"
     );
 }
 
@@ -901,7 +904,8 @@ static void sp_256_sqr_sm2_8(sp_digit* r, const sp_digit* a)
 #endif
         : [r] "+r" (r), [a] "+r" (a)
         :
-        : "memory", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "lr", "r11", "cc"
+        : "memory", "cc", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "lr",
+            "r11"
     );
 }
 
@@ -1073,7 +1077,7 @@ SP_NOINLINE static void sp_256_sqr_sm2_8(sp_digit* r, const sp_digit* a)
         "ADD	lr, sp, #0x20\n\t"
         "STM	lr, {r3, r4, r5, r6, r7, r8, r9}\n\t"
         "ADD	lr, sp, #0x4\n\t"
-        "LDM	lr, {r4, r5, r6, r7, r8, r9, r10}\n\t"
+        "ldm   lr, {r4, r5, r6, r7, r8, r9, r10}\n\t"
         "ADDS	r4, r4, r4\n\t"
         "ADCS	r5, r5, r5\n\t"
         "ADCS	r6, r6, r6\n\t"
@@ -1082,7 +1086,7 @@ SP_NOINLINE static void sp_256_sqr_sm2_8(sp_digit* r, const sp_digit* a)
         "ADCS	r9, r9, r9\n\t"
         "ADCS	r10, r10, r10\n\t"
         "STM	lr!, {r4, r5, r6, r7, r8, r9, r10}\n\t"
-        "LDM	lr, {r3, r4, r5, r6, r7, r8, r9}\n\t"
+        "ldm   lr, {r3, r4, r5, r6, r7, r8, r9}\n\t"
         "ADCS	r3, r3, r3\n\t"
         "ADCS	r4, r4, r4\n\t"
         "ADCS	r5, r5, r5\n\t"
@@ -1093,7 +1097,7 @@ SP_NOINLINE static void sp_256_sqr_sm2_8(sp_digit* r, const sp_digit* a)
         "ADC	r10, %[r], #0x0\n\t"
         "STM	lr, {r3, r4, r5, r6, r7, r8, r9, r10}\n\t"
         "ADD	lr, sp, #0x4\n\t"
-        "LDM	lr, {r4, r5, r6, r7, r8, r9, r10}\n\t"
+        "ldm   lr, {r4, r5, r6, r7, r8, r9, r10}\n\t"
         "MOV	lr, sp\n\t"
         /* A[0] * A[0] */
         "LDR	r12, [%[a]]\n\t"
@@ -1118,7 +1122,7 @@ SP_NOINLINE static void sp_256_sqr_sm2_8(sp_digit* r, const sp_digit* a)
         "UMLAL	r9, r11, r12, r12\n\t"
         "ADDS	r10, r10, r11\n\t"
         "STM	lr!, {r3, r4, r5, r6, r7, r8, r9, r10}\n\t"
-        "LDM	lr, {r3, r4, r5, r6, r7, r8, r9, r10}\n\t"
+        "ldm   lr, {r3, r4, r5, r6, r7, r8, r9, r10}\n\t"
         /* A[4] * A[4] */
         "LDR	r12, [%[a], #16]\n\t"
         "ADCS	r3, r3, #0x0\n\t"
@@ -1145,13 +1149,14 @@ SP_NOINLINE static void sp_256_sqr_sm2_8(sp_digit* r, const sp_digit* a)
         "LDR	%[r], [sp, #64]\n\t"
         "ADD	%[r], %[r], #0x20\n\t"
         "STM	%[r], {r3, r4, r5, r6, r7, r8, r9, r10}\n\t"
-        "LDM	sp, {r3, r4, r5, r6, r7, r8, r9, r10}\n\t"
+        "ldm   sp, {r3, r4, r5, r6, r7, r8, r9, r10}\n\t"
         "SUB	%[r], %[r], #0x20\n\t"
         "STM	%[r], {r3, r4, r5, r6, r7, r8, r9, r10}\n\t"
         "ADD	sp, sp, #0x44\n\t"
         : [r] "+r" (r), [a] "+r" (a)
         :
-        : "memory", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12", "lr", "cc"
+        : "memory", "cc", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10",
+            "r11", "r12", "lr"
     );
 }
 
@@ -1175,7 +1180,7 @@ SP_NOINLINE static void sp_256_sqr_sm2_8(sp_digit* r, const sp_digit* a)
     __asm__ __volatile__ (
         "SUB	sp, sp, #0x20\n\t"
         "STR	%[r], [sp, #28]\n\t"
-        "LDM	%[a], {r0, r1, r2, r3, r4, r5, r6, r7}\n\t"
+        "ldm   %[a], {r0, r1, r2, r3, r4, r5, r6, r7}\n\t"
         "UMULL	r9, r10, r0, r0\n\t"
         "UMULL	r11, r12, r0, r1\n\t"
         "ADDS	r11, r11, r11\n\t"
@@ -1263,12 +1268,13 @@ SP_NOINLINE static void sp_256_sqr_sm2_8(sp_digit* r, const sp_digit* a)
         "STM	lr!, {r3, r4, r8, r9}\n\t"
         "STM	lr!, {r7}\n\t"
         "SUB	lr, lr, #0x40\n\t"
-        "LDM	sp, {r0, r1, r2, r3, r4, r5, r6}\n\t"
+        "ldm   sp, {r0, r1, r2, r3, r4, r5, r6}\n\t"
         "STM	lr, {r0, r1, r2, r3, r4, r5, r6}\n\t"
         "ADD	sp, sp, #0x20\n\t"
         : [r] "+r" (r), [a] "+r" (a)
         :
-        : "memory", "r2", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12", "lr", "cc"
+        : "memory", "cc", "r2", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10",
+            "r11", "r12", "lr"
     );
 }
 
@@ -1282,9 +1288,11 @@ SP_NOINLINE static void sp_256_sqr_sm2_8(sp_digit* r, const sp_digit* a)
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_256_add_sm2_8(sp_digit* r_p, const sp_digit* a_p, const sp_digit* b_p)
+static sp_digit sp_256_add_sm2_8(sp_digit* r_p, const sp_digit* a_p,
+    const sp_digit* b_p)
 #else
-static sp_digit sp_256_add_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit* b)
+static sp_digit sp_256_add_sm2_8(sp_digit* r, const sp_digit* a,
+    const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -1323,9 +1331,10 @@ static sp_digit sp_256_add_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit*
         "MOV	%[r], r3\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
         :
-        : "memory", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r3", "r12", "cc"
+        : "memory", "cc", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11",
+            "r3", "r12"
     );
-    return (uint32_t)(size_t)r;
+    return (word32)(size_t)r;
 }
 
 #else
@@ -1336,9 +1345,11 @@ static sp_digit sp_256_add_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit*
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_256_add_sm2_8(sp_digit* r_p, const sp_digit* a_p, const sp_digit* b_p)
+static sp_digit sp_256_add_sm2_8(sp_digit* r_p, const sp_digit* a_p,
+    const sp_digit* b_p)
 #else
-static sp_digit sp_256_add_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit* b)
+static sp_digit sp_256_add_sm2_8(sp_digit* r, const sp_digit* a,
+    const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -1366,9 +1377,9 @@ static sp_digit sp_256_add_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit*
         "ADC	%[r], %[r], #0x0\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
         :
-        : "memory", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "cc"
+        : "memory", "cc", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10"
     );
-    return (uint32_t)(size_t)r;
+    return (word32)(size_t)r;
 }
 
 #endif /* WOLFSSL_SP_SMALL */
@@ -1399,7 +1410,7 @@ static sp_digit sp_256_sub_in_place_sm2_8(sp_digit* a, const sp_digit* b)
     "L_sp_256_sub_in_pkace_sm2_8_word_%=:\n\t"
 #endif
         "RSBS	r10, r10, #0x0\n\t"
-        "LDM	%[a], {r2, r3, r4, r5}\n\t"
+        "ldm   %[a], {r2, r3, r4, r5}\n\t"
         "LDM	%[b]!, {r6, r7, r8, r9}\n\t"
         "SBCS	r2, r2, r6\n\t"
         "SBCS	r3, r3, r7\n\t"
@@ -1418,9 +1429,10 @@ static sp_digit sp_256_sub_in_place_sm2_8(sp_digit* a, const sp_digit* b)
         "MOV	%[a], r10\n\t"
         : [a] "+r" (a), [b] "+r" (b)
         :
-        : "memory", "r2", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "cc"
+        : "memory", "cc", "r2", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10",
+            "r11"
     );
-    return (uint32_t)(size_t)a;
+    return (word32)(size_t)a;
 }
 
 #else
@@ -1441,14 +1453,14 @@ static sp_digit sp_256_sub_in_place_sm2_8(sp_digit* a, const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 
     __asm__ __volatile__ (
-        "LDM	%[a], {r2, r3, r4, r5}\n\t"
+        "ldm   %[a], {r2, r3, r4, r5}\n\t"
         "LDM	%[b]!, {r6, r7, r8, r9}\n\t"
         "SUBS	r2, r2, r6\n\t"
         "SBCS	r3, r3, r7\n\t"
         "SBCS	r4, r4, r8\n\t"
         "SBCS	r5, r5, r9\n\t"
         "STM	%[a]!, {r2, r3, r4, r5}\n\t"
-        "LDM	%[a], {r2, r3, r4, r5}\n\t"
+        "ldm   %[a], {r2, r3, r4, r5}\n\t"
         "LDM	%[b]!, {r6, r7, r8, r9}\n\t"
         "SBCS	r2, r2, r6\n\t"
         "SBCS	r3, r3, r7\n\t"
@@ -1458,9 +1470,9 @@ static sp_digit sp_256_sub_in_place_sm2_8(sp_digit* a, const sp_digit* b)
         "SBC	%[a], r9, r9\n\t"
         : [a] "+r" (a), [b] "+r" (b)
         :
-        : "memory", "r2", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "cc"
+        : "memory", "cc", "r2", "r3", "r4", "r5", "r6", "r7", "r8", "r9"
     );
-    return (uint32_t)(size_t)a;
+    return (word32)(size_t)a;
 }
 
 #endif /* WOLFSSL_SP_SMALL */
@@ -1474,9 +1486,11 @@ static sp_digit sp_256_sub_in_place_sm2_8(sp_digit* a, const sp_digit* b)
  * m  Mask value to apply.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_256_cond_sub_sm2_8(sp_digit* r_p, const sp_digit* a_p, const sp_digit* b_p, sp_digit m_p)
+static sp_digit sp_256_cond_sub_sm2_8(sp_digit* r_p, const sp_digit* a_p,
+    const sp_digit* b_p, sp_digit m_p)
 #else
-static sp_digit sp_256_cond_sub_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit* b, sp_digit m)
+static sp_digit sp_256_cond_sub_sm2_8(sp_digit* r, const sp_digit* a,
+    const sp_digit* b, sp_digit m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -1515,9 +1529,9 @@ static sp_digit sp_256_cond_sub_sm2_8(sp_digit* r, const sp_digit* a, const sp_d
         "MOV	%[r], r4\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b), [m] "+r" (m)
         :
-        : "memory", "r4", "r5", "r6", "r7", "r8", "cc"
+        : "memory", "cc", "r4", "r5", "r6", "r7", "r8"
     );
-    return (uint32_t)(size_t)r;
+    return (word32)(size_t)r;
 }
 
 #else
@@ -1530,9 +1544,11 @@ static sp_digit sp_256_cond_sub_sm2_8(sp_digit* r, const sp_digit* a, const sp_d
  * m  Mask value to apply.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_256_cond_sub_sm2_8(sp_digit* r_p, const sp_digit* a_p, const sp_digit* b_p, sp_digit m_p)
+static sp_digit sp_256_cond_sub_sm2_8(sp_digit* r_p, const sp_digit* a_p,
+    const sp_digit* b_p, sp_digit m_p)
 #else
-static sp_digit sp_256_cond_sub_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit* b, sp_digit m)
+static sp_digit sp_256_cond_sub_sm2_8(sp_digit* r, const sp_digit* a,
+    const sp_digit* b, sp_digit m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -1575,9 +1591,9 @@ static sp_digit sp_256_cond_sub_sm2_8(sp_digit* r, const sp_digit* a, const sp_d
         "SBC	%[r], r5, r5\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b), [m] "+r" (m)
         :
-        : "memory", "r4", "r5", "r6", "r7", "r8", "r9", "cc"
+        : "memory", "cc", "r4", "r5", "r6", "r7", "r8", "r9"
     );
-    return (uint32_t)(size_t)r;
+    return (word32)(size_t)r;
 }
 
 #endif /* WOLFSSL_SP_SMALL */
@@ -1636,7 +1652,7 @@ static void sp_256_mul_d_sm2_8(sp_digit* r, const sp_digit* a, sp_digit b)
         "STR	r3, [%[r], #32]\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
         :
-        : "memory", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "cc"
+        : "memory", "cc", "r3", "r4", "r5", "r6", "r7", "r8", "r9"
     );
 }
 
@@ -1702,7 +1718,7 @@ static void sp_256_mul_d_sm2_8(sp_digit* r, const sp_digit* a, sp_digit b)
         "STR	r5, [%[r]]\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
         :
-        : "memory", "r3", "r4", "r5", "r6", "r7", "r8", "cc"
+        : "memory", "cc", "r3", "r4", "r5", "r6", "r7", "r8"
     );
 }
 
@@ -1718,9 +1734,11 @@ static void sp_256_mul_d_sm2_8(sp_digit* r, const sp_digit* a, sp_digit b)
  * Note that this is an approximate div. It may give an answer 1 larger.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static sp_digit div_256_word_8(sp_digit d1_p, sp_digit d0_p, sp_digit div_p)
+SP_NOINLINE static sp_digit div_256_word_8(sp_digit d1_p, sp_digit d0_p,
+    sp_digit div_p)
 #else
-SP_NOINLINE static sp_digit div_256_word_8(sp_digit d1, sp_digit d0, sp_digit div)
+SP_NOINLINE static sp_digit div_256_word_8(sp_digit d1, sp_digit d0,
+    sp_digit div)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -1767,9 +1785,9 @@ SP_NOINLINE static sp_digit div_256_word_8(sp_digit d1, sp_digit d0, sp_digit di
         "ADD	%[d1], r6, r3\n\t"
         : [d1] "+r" (d1), [d0] "+r" (d0), [div] "+r" (div)
         :
-        : "memory", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "cc"
+        : "memory", "cc", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10"
     );
-    return (uint32_t)(size_t)d1;
+    return (word32)(size_t)d1;
 }
 
 #else
@@ -1783,9 +1801,11 @@ SP_NOINLINE static sp_digit div_256_word_8(sp_digit d1, sp_digit d0, sp_digit di
  * Note that this is an approximate div. It may give an answer 1 larger.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static sp_digit div_256_word_8(sp_digit d1_p, sp_digit d0_p, sp_digit div_p)
+SP_NOINLINE static sp_digit div_256_word_8(sp_digit d1_p, sp_digit d0_p,
+    sp_digit div_p)
 #else
-SP_NOINLINE static sp_digit div_256_word_8(sp_digit d1, sp_digit d0, sp_digit div)
+SP_NOINLINE static sp_digit div_256_word_8(sp_digit d1, sp_digit d0,
+    sp_digit div)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -1849,9 +1869,9 @@ SP_NOINLINE static sp_digit div_256_word_8(sp_digit d1, sp_digit d0, sp_digit di
         "SUB	%[d1], r3, r8\n\t"
         : [d1] "+r" (d1), [d0] "+r" (d0), [div] "+r" (div)
         :
-        : "memory", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "cc"
+        : "memory", "cc", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10"
     );
-    return (uint32_t)(size_t)d1;
+    return (word32)(size_t)d1;
 }
 
 #endif
@@ -2024,9 +2044,9 @@ static sp_int32 sp_256_cmp_sm2_8(const sp_digit* a, const sp_digit* b)
         "MOV	%[a], r2\n\t"
         : [a] "+r" (a), [b] "+r" (b)
         :
-        : "memory", "r2", "r3", "r4", "r5", "r6", "r7", "r8", "cc"
+        : "memory", "cc", "r2", "r3", "r4", "r5", "r6", "r7", "r8"
     );
-    return (uint32_t)(size_t)a;
+    return (word32)(size_t)a;
 }
 
 /* Divide d in a and put remainder into r (m*d + r = a)
@@ -2304,9 +2324,11 @@ static int sp_256_point_to_ecc_point_8(const sp_point_256* p, ecc_point* pm)
  * mp  Montgomery multiplier.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_256_mont_mul_sm2_8(sp_digit* r_p, const sp_digit* a_p, const sp_digit* b_p, const sp_digit* m_p, sp_digit mp_p)
+static void sp_256_mont_mul_sm2_8(sp_digit* r_p, const sp_digit* a_p,
+    const sp_digit* b_p, const sp_digit* m_p, sp_digit mp_p)
 #else
-static void sp_256_mont_mul_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit* b, const sp_digit* m, sp_digit mp)
+static void sp_256_mont_mul_sm2_8(sp_digit* r, const sp_digit* a,
+    const sp_digit* b, const sp_digit* m, sp_digit mp)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -2645,7 +2667,7 @@ static void sp_256_mont_mul_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit
         "ADD	lr, sp, #0x20\n\t"
         "STM	lr, {r3, r4, r5, r6, r7, r8, r9, r10}\n\t"
         /* Start Reduction */
-        "LDM	sp, {r5, r6, r7, r8, r9, r10, r11, r12}\n\t"
+        "ldm   sp, {r5, r6, r7, r8, r9, r10, r11, r12}\n\t"
         "MOV	r3, r11\n\t"
         "MOV	r4, r12\n\t"
         /* mu = a[0..7] + a[0..5] << 64 - a[0..4] << 96 */
@@ -2707,7 +2729,7 @@ static void sp_256_mont_mul_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit
         /* a[10] +=  t[2]        = r[2] + t[7] + t[3] */
         /* a[11] +=  t[3]        = r[3] +        t[4] */
         "ADD	r0, sp, #0x20\n\t"
-        "LDM	r0, {r1, r2, r3, r4}\n\t"
+        "ldm   r0, {r1, r2, r3, r4}\n\t"
         "ADCS	r1, r1, r5\n\t"
         "ADCS	r2, r2, r6\n\t"
         "ADCS	r3, r3, r7\n\t"
@@ -2725,7 +2747,7 @@ static void sp_256_mont_mul_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit
         /* a[14] +=  t[6]        = r[6] +        t[7] */
         /* a[15] +=  t[7]        = r[7] */
         "ADD	r0, sp, #0x30\n\t"
-        "LDM	r0, {r1, r2, r3, r4}\n\t"
+        "ldm   r0, {r1, r2, r3, r4}\n\t"
         "ADDS	lr, lr, #0x-1\n\t"
         "ADCS	r1, r1, r9\n\t"
         "ADCS	r2, r2, r10\n\t"
@@ -2740,7 +2762,7 @@ static void sp_256_mont_mul_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit
         /* a[5]  += -t[2]        = t[5] */
         /* a[6]  += -t[3]        = t[6] */
         "ADD	r0, sp, #0xc\n\t"
-        "LDM	r0, {r0, r1, r2, r3}\n\t"
+        "ldm   r0, {r0, r1, r2, r3}\n\t"
         "SUBS	r0, r0, r5\n\t"
         "SBCS	r1, r1, r6\n\t"
         "SBCS	r2, r2, r7\n\t"
@@ -2750,7 +2772,7 @@ static void sp_256_mont_mul_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit
         /* a[9]  += -t[6] - t[2] = r[1] */
         /* a[10] += -t[7] - t[3] = r[2] */
         "ADD	r0, sp, #0x1c\n\t"
-        "LDM	r0, {r0, r1, r2, r3}\n\t"
+        "ldm   r0, {r0, r1, r2, r3}\n\t"
         "SBCS	r0, r0, r9\n\t"
         "SBCS	r1, r1, r10\n\t"
         "SBCS	r2, r2, r11\n\t"
@@ -2768,7 +2790,7 @@ static void sp_256_mont_mul_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit
         /* a[14] +=       - t[7] = r[6] */
         /* a[15] +=              = r[7] */
         "ADD	r0, sp, #0x2c\n\t"
-        "LDM	r0, {r4, r5, r6, r7, r8}\n\t"
+        "ldm   r0, {r4, r5, r6, r7, r8}\n\t"
         "RSB	lr, lr, #0x0\n\t"
         "SUBS	r4, r4, lr\n\t"
         "SBCS	r5, r5, #0x0\n\t"
@@ -2800,7 +2822,8 @@ static void sp_256_mont_mul_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit
         "ADD	sp, sp, #0x44\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
         :
-        : "memory", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12", "lr", "cc"
+        : "memory", "cc", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10",
+            "r11", "r12", "lr"
     );
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     (void)m_p;
@@ -2825,9 +2848,11 @@ static void sp_256_mont_mul_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit
  * mp  Montgomery multiplier.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_256_mont_mul_sm2_8(sp_digit* r_p, const sp_digit* a_p, const sp_digit* b_p, const sp_digit* m_p, sp_digit mp_p)
+static void sp_256_mont_mul_sm2_8(sp_digit* r_p, const sp_digit* a_p,
+    const sp_digit* b_p, const sp_digit* m_p, sp_digit mp_p)
 #else
-static void sp_256_mont_mul_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit* b, const sp_digit* m, sp_digit mp)
+static void sp_256_mont_mul_sm2_8(sp_digit* r, const sp_digit* a,
+    const sp_digit* b, const sp_digit* m, sp_digit mp)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -2840,8 +2865,8 @@ static void sp_256_mont_mul_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit
         "SUB	sp, sp, #0x4c\n\t"
         "STRD	%[r], %[a], [sp, #68]\n\t"
         "MOV	lr, %[b]\n\t"
-        "LDM	%[a], {%[r], %[a], %[b], r3}\n\t"
-        "LDM	lr!, {r4, r5, r6}\n\t"
+        "ldm   %[a], {r0, r1, r2, r3}\n\t"
+        "ldm   lr!, {r4, r5, r6}\n\t"
         "UMULL	r10, r11, %[r], r4\n\t"
         "UMULL	r12, r7, %[a], r4\n\t"
         "UMAAL	r11, r12, %[r], r5\n\t"
@@ -2851,7 +2876,7 @@ static void sp_256_mont_mul_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit
         "UMAAL	r8, r9, r3, r4\n\t"
         "STM	sp, {r10, r11, r12}\n\t"
         "UMAAL	r7, r8, %[b], r5\n\t"
-        "LDM	lr!, {r4}\n\t"
+        "ldm   lr!, {r4}\n\t"
         "UMULL	r10, r11, %[a], r6\n\t"
         "UMAAL	r8, r9, %[b], r6\n\t"
         "UMAAL	r7, r10, %[r], r4\n\t"
@@ -2861,7 +2886,7 @@ static void sp_256_mont_mul_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit
         "UMAAL	r9, r11, r3, r6\n\t"
         "UMAAL	r9, r10, %[b], r4\n\t"
         "UMAAL	r10, r11, r3, r4\n\t"
-        "LDM	lr, {r4, r5, r6, r7}\n\t"
+        "ldm   lr, {r4, r5, r6, r7}\n\t"
         "MOV	r12, #0x0\n\t"
         "UMLAL	r8, r12, %[r], r4\n\t"
         "UMAAL	r9, r12, %[a], r4\n\t"
@@ -2885,48 +2910,48 @@ static void sp_256_mont_mul_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit
         "UMAAL	r4, r6, %[b], r7\n\t"
         "SUB	lr, lr, #0x10\n\t"
         "UMAAL	r5, r6, r3, r7\n\t"
-        "LDM	%[r], {%[r], %[a], %[b], r3}\n\t"
+        "ldm   %[r], {r0, r1, r2, r3}\n\t"
         "STR	r6, [sp, #64]\n\t"
-        "LDM	lr!, {r6}\n\t"
+        "ldm   lr!, {r6}\n\t"
         "MOV	r7, #0x0\n\t"
         "UMLAL	r8, r7, %[r], r6\n\t"
         "UMAAL	r9, r7, %[a], r6\n\t"
         "STR	r8, [sp, #16]\n\t"
         "UMAAL	r10, r7, %[b], r6\n\t"
         "UMAAL	r11, r7, r3, r6\n\t"
-        "LDM	lr!, {r6}\n\t"
+        "ldm   lr!, {r6}\n\t"
         "MOV	r8, #0x0\n\t"
         "UMLAL	r9, r8, %[r], r6\n\t"
         "UMAAL	r10, r8, %[a], r6\n\t"
         "STR	r9, [sp, #20]\n\t"
         "UMAAL	r11, r8, %[b], r6\n\t"
         "UMAAL	r12, r8, r3, r6\n\t"
-        "LDM	lr!, {r6}\n\t"
+        "ldm   lr!, {r6}\n\t"
         "MOV	r9, #0x0\n\t"
         "UMLAL	r10, r9, %[r], r6\n\t"
         "UMAAL	r11, r9, %[a], r6\n\t"
         "STR	r10, [sp, #24]\n\t"
         "UMAAL	r12, r9, %[b], r6\n\t"
         "UMAAL	r4, r9, r3, r6\n\t"
-        "LDM	lr!, {r6}\n\t"
+        "ldm   lr!, {r6}\n\t"
         "MOV	r10, #0x0\n\t"
         "UMLAL	r11, r10, %[r], r6\n\t"
         "UMAAL	r12, r10, %[a], r6\n\t"
         "STR	r11, [sp, #28]\n\t"
         "UMAAL	r4, r10, %[b], r6\n\t"
         "UMAAL	r5, r10, r3, r6\n\t"
-        "LDM	lr!, {r11}\n\t"
+        "ldm   lr!, {r11}\n\t"
         "UMAAL	r12, r7, %[r], r11\n\t"
         "UMAAL	r4, r7, %[a], r11\n\t"
         "LDR	r6, [sp, #64]\n\t"
         "UMAAL	r5, r7, %[b], r11\n\t"
         "UMAAL	r6, r7, r3, r11\n\t"
-        "LDM	lr!, {r11}\n\t"
+        "ldm   lr!, {r11}\n\t"
         "UMAAL	r4, r8, %[r], r11\n\t"
         "UMAAL	r5, r8, %[a], r11\n\t"
         "UMAAL	r6, r8, %[b], r11\n\t"
         "UMAAL	r7, r8, r3, r11\n\t"
-        "LDM	lr, {r11, lr}\n\t"
+        "ldm   lr, {r11, lr}\n\t"
         "UMAAL	r5, r9, %[r], r11\n\t"
         "UMAAL	r6, r10, %[r], lr\n\t"
         "UMAAL	r6, r9, %[a], r11\n\t"
@@ -2939,7 +2964,7 @@ static void sp_256_mont_mul_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit
         "ADD	lr, sp, #0x20\n\t"
         "STM	lr, {r3, r4, r5, r6, r7, r8, r9, r10}\n\t"
         /* Start Reduction */
-        "LDM	sp, {r5, r6, r7, r8, r9, r10, r11, r12}\n\t"
+        "ldm   sp, {r5, r6, r7, r8, r9, r10, r11, r12}\n\t"
         "MOV	r3, r11\n\t"
         "MOV	r4, r12\n\t"
         /* mu = a[0..7] + a[0..5] << 64 - a[0..4] << 96 */
@@ -3001,7 +3026,7 @@ static void sp_256_mont_mul_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit
         /* a[10] +=  t[2]        = r[2] + t[7] + t[3] */
         /* a[11] +=  t[3]        = r[3] +        t[4] */
         "ADD	r0, sp, #0x20\n\t"
-        "LDM	r0, {r1, r2, r3, r4}\n\t"
+        "ldm   r0, {r1, r2, r3, r4}\n\t"
         "ADCS	r1, r1, r5\n\t"
         "ADCS	r2, r2, r6\n\t"
         "ADCS	r3, r3, r7\n\t"
@@ -3019,7 +3044,7 @@ static void sp_256_mont_mul_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit
         /* a[14] +=  t[6]        = r[6] +        t[7] */
         /* a[15] +=  t[7]        = r[7] */
         "ADD	r0, sp, #0x30\n\t"
-        "LDM	r0, {r1, r2, r3, r4}\n\t"
+        "ldm   r0, {r1, r2, r3, r4}\n\t"
         "ADDS	lr, lr, #0x-1\n\t"
         "ADCS	r1, r1, r9\n\t"
         "ADCS	r2, r2, r10\n\t"
@@ -3034,7 +3059,7 @@ static void sp_256_mont_mul_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit
         /* a[5]  += -t[2]        = t[5] */
         /* a[6]  += -t[3]        = t[6] */
         "ADD	r0, sp, #0xc\n\t"
-        "LDM	r0, {r0, r1, r2, r3}\n\t"
+        "ldm   r0, {r0, r1, r2, r3}\n\t"
         "SUBS	r0, r0, r5\n\t"
         "SBCS	r1, r1, r6\n\t"
         "SBCS	r2, r2, r7\n\t"
@@ -3044,7 +3069,7 @@ static void sp_256_mont_mul_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit
         /* a[9]  += -t[6] - t[2] = r[1] */
         /* a[10] += -t[7] - t[3] = r[2] */
         "ADD	r0, sp, #0x1c\n\t"
-        "LDM	r0, {r0, r1, r2, r3}\n\t"
+        "ldm   r0, {r0, r1, r2, r3}\n\t"
         "SBCS	r0, r0, r9\n\t"
         "SBCS	r1, r1, r10\n\t"
         "SBCS	r2, r2, r11\n\t"
@@ -3062,7 +3087,7 @@ static void sp_256_mont_mul_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit
         /* a[14] +=       - t[7] = r[6] */
         /* a[15] +=              = r[7] */
         "ADD	r0, sp, #0x2c\n\t"
-        "LDM	r0, {r4, r5, r6, r7, r8}\n\t"
+        "ldm   r0, {r4, r5, r6, r7, r8}\n\t"
         "RSB	lr, lr, #0x0\n\t"
         "SUBS	r4, r4, lr\n\t"
         "SBCS	r5, r5, #0x0\n\t"
@@ -3094,7 +3119,8 @@ static void sp_256_mont_mul_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit
         "ADD	sp, sp, #0x4c\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
         :
-        : "memory", "r3", "r4", "r5", "r6", "r10", "r11", "r12", "r7", "r8", "r9", "lr", "cc"
+        : "memory", "cc", "r3", "r4", "r5", "r6", "r10", "r11", "r12", "r7",
+            "r8", "r9", "lr"
     );
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     (void)m_p;
@@ -3118,9 +3144,11 @@ static void sp_256_mont_mul_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit
  * mp  Montgomery multiplier.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_256_mont_sqr_sm2_8(sp_digit* r_p, const sp_digit* a_p, const sp_digit* m_p, sp_digit mp_p)
+static void sp_256_mont_sqr_sm2_8(sp_digit* r_p, const sp_digit* a_p,
+    const sp_digit* m_p, sp_digit mp_p)
 #else
-static void sp_256_mont_sqr_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit* m, sp_digit mp)
+static void sp_256_mont_sqr_sm2_8(sp_digit* r, const sp_digit* a,
+    const sp_digit* m, sp_digit mp)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -3278,7 +3306,7 @@ static void sp_256_mont_sqr_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit
         "ADD	lr, sp, #0x20\n\t"
         "STM	lr, {r3, r4, r5, r6, r7, r8, r9}\n\t"
         "ADD	lr, sp, #0x4\n\t"
-        "LDM	lr, {r4, r5, r6, r7, r8, r9, r10}\n\t"
+        "ldm   lr, {r4, r5, r6, r7, r8, r9, r10}\n\t"
         "ADDS	r4, r4, r4\n\t"
         "ADCS	r5, r5, r5\n\t"
         "ADCS	r6, r6, r6\n\t"
@@ -3287,7 +3315,7 @@ static void sp_256_mont_sqr_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit
         "ADCS	r9, r9, r9\n\t"
         "ADCS	r10, r10, r10\n\t"
         "STM	lr!, {r4, r5, r6, r7, r8, r9, r10}\n\t"
-        "LDM	lr, {r3, r4, r5, r6, r7, r8, r9}\n\t"
+        "ldm   lr, {r3, r4, r5, r6, r7, r8, r9}\n\t"
         "ADCS	r3, r3, r3\n\t"
         "ADCS	r4, r4, r4\n\t"
         "ADCS	r5, r5, r5\n\t"
@@ -3298,7 +3326,7 @@ static void sp_256_mont_sqr_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit
         "ADC	r10, %[r], #0x0\n\t"
         "STM	lr, {r3, r4, r5, r6, r7, r8, r9, r10}\n\t"
         "ADD	lr, sp, #0x4\n\t"
-        "LDM	lr, {r4, r5, r6, r7, r8, r9, r10}\n\t"
+        "ldm   lr, {r4, r5, r6, r7, r8, r9, r10}\n\t"
         "MOV	lr, sp\n\t"
         /* A[0] * A[0] */
         "LDR	r12, [%[a]]\n\t"
@@ -3323,7 +3351,7 @@ static void sp_256_mont_sqr_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit
         "UMLAL	r9, r11, r12, r12\n\t"
         "ADDS	r10, r10, r11\n\t"
         "STM	lr!, {r3, r4, r5, r6, r7, r8, r9, r10}\n\t"
-        "LDM	lr, {r3, r4, r5, r6, r7, r8, r9, r10}\n\t"
+        "ldm   lr, {r3, r4, r5, r6, r7, r8, r9, r10}\n\t"
         /* A[4] * A[4] */
         "LDR	r12, [%[a], #16]\n\t"
         "ADCS	r3, r3, #0x0\n\t"
@@ -3350,7 +3378,7 @@ static void sp_256_mont_sqr_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit
         "ADD	lr, sp, #0x20\n\t"
         "STM	lr, {r3, r4, r5, r6, r7, r8, r9, r10}\n\t"
         /* Start Reduction */
-        "LDM	sp, {r5, r6, r7, r8, r9, r10, r11, r12}\n\t"
+        "ldm   sp, {r5, r6, r7, r8, r9, r10, r11, r12}\n\t"
         "MOV	r3, r11\n\t"
         "MOV	r4, r12\n\t"
         /* mu = a[0..7] + a[0..5] << 64 - a[0..4] << 96 */
@@ -3412,7 +3440,7 @@ static void sp_256_mont_sqr_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit
         /* a[10] +=  t[2]        = r[2] + t[7] + t[3] */
         /* a[11] +=  t[3]        = r[3] +        t[4] */
         "ADD	r0, sp, #0x20\n\t"
-        "LDM	r0, {r1, r2, r3, r4}\n\t"
+        "ldm   r0, {r1, r2, r3, r4}\n\t"
         "ADCS	r1, r1, r5\n\t"
         "ADCS	r2, r2, r6\n\t"
         "ADCS	r3, r3, r7\n\t"
@@ -3430,7 +3458,7 @@ static void sp_256_mont_sqr_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit
         /* a[14] +=  t[6]        = r[6] +        t[7] */
         /* a[15] +=  t[7]        = r[7] */
         "ADD	r0, sp, #0x30\n\t"
-        "LDM	r0, {r1, r2, r3, r4}\n\t"
+        "ldm   r0, {r1, r2, r3, r4}\n\t"
         "ADDS	lr, lr, #0x-1\n\t"
         "ADCS	r1, r1, r9\n\t"
         "ADCS	r2, r2, r10\n\t"
@@ -3445,7 +3473,7 @@ static void sp_256_mont_sqr_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit
         /* a[5]  += -t[2]        = t[5] */
         /* a[6]  += -t[3]        = t[6] */
         "ADD	r0, sp, #0xc\n\t"
-        "LDM	r0, {r0, r1, r2, r3}\n\t"
+        "ldm   r0, {r0, r1, r2, r3}\n\t"
         "SUBS	r0, r0, r5\n\t"
         "SBCS	r1, r1, r6\n\t"
         "SBCS	r2, r2, r7\n\t"
@@ -3455,7 +3483,7 @@ static void sp_256_mont_sqr_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit
         /* a[9]  += -t[6] - t[2] = r[1] */
         /* a[10] += -t[7] - t[3] = r[2] */
         "ADD	r0, sp, #0x1c\n\t"
-        "LDM	r0, {r0, r1, r2, r3}\n\t"
+        "ldm   r0, {r0, r1, r2, r3}\n\t"
         "SBCS	r0, r0, r9\n\t"
         "SBCS	r1, r1, r10\n\t"
         "SBCS	r2, r2, r11\n\t"
@@ -3473,7 +3501,7 @@ static void sp_256_mont_sqr_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit
         /* a[14] +=       - t[7] = r[6] */
         /* a[15] +=              = r[7] */
         "ADD	r0, sp, #0x2c\n\t"
-        "LDM	r0, {r4, r5, r6, r7, r8}\n\t"
+        "ldm   r0, {r4, r5, r6, r7, r8}\n\t"
         "RSB	lr, lr, #0x0\n\t"
         "SUBS	r4, r4, lr\n\t"
         "SBCS	r5, r5, #0x0\n\t"
@@ -3505,7 +3533,8 @@ static void sp_256_mont_sqr_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit
         "ADD	sp, sp, #0x44\n\t"
         : [r] "+r" (r), [a] "+r" (a)
         :
-        : "memory", "r2", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12", "lr", "cc"
+        : "memory", "cc", "r2", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10",
+            "r11", "r12", "lr"
     );
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     (void)m_p;
@@ -3528,9 +3557,11 @@ static void sp_256_mont_sqr_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit
  * mp  Montgomery multiplier.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_256_mont_sqr_sm2_8(sp_digit* r_p, const sp_digit* a_p, const sp_digit* m_p, sp_digit mp_p)
+static void sp_256_mont_sqr_sm2_8(sp_digit* r_p, const sp_digit* a_p,
+    const sp_digit* m_p, sp_digit mp_p)
 #else
-static void sp_256_mont_sqr_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit* m, sp_digit mp)
+static void sp_256_mont_sqr_sm2_8(sp_digit* r, const sp_digit* a,
+    const sp_digit* m, sp_digit mp)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -3541,7 +3572,7 @@ static void sp_256_mont_sqr_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit
     __asm__ __volatile__ (
         "SUB	sp, sp, #0x44\n\t"
         "STR	%[r], [sp, #64]\n\t"
-        "LDM	%[a], {%[r], %[a], r2, r3, r4, r5, r6, r7}\n\t"
+        "ldm   %[a], {r0, r1, r2, r3, r4, r5, r6, r7}\n\t"
         "UMULL	r9, r10, %[r], %[r]\n\t"
         "UMULL	r11, r12, %[r], %[a]\n\t"
         "ADDS	r11, r11, r11\n\t"
@@ -3629,7 +3660,7 @@ static void sp_256_mont_sqr_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit
         "STM	lr!, {r3, r4, r8, r9}\n\t"
         "STM	lr!, {r7}\n\t"
         /* Start Reduction */
-        "LDM	sp, {r5, r6, r7, r8, r9, r10, r11, r12}\n\t"
+        "ldm   sp, {r5, r6, r7, r8, r9, r10, r11, r12}\n\t"
         "MOV	r3, r11\n\t"
         "MOV	r4, r12\n\t"
         /* mu = a[0..7] + a[0..5] << 64 - a[0..4] << 96 */
@@ -3691,7 +3722,7 @@ static void sp_256_mont_sqr_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit
         /* a[10] +=  t[2]        = r[2] + t[7] + t[3] */
         /* a[11] +=  t[3]        = r[3] +        t[4] */
         "ADD	r0, sp, #0x20\n\t"
-        "LDM	r0, {r1, r2, r3, r4}\n\t"
+        "ldm   r0, {r1, r2, r3, r4}\n\t"
         "ADCS	r1, r1, r5\n\t"
         "ADCS	r2, r2, r6\n\t"
         "ADCS	r3, r3, r7\n\t"
@@ -3709,7 +3740,7 @@ static void sp_256_mont_sqr_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit
         /* a[14] +=  t[6]        = r[6] +        t[7] */
         /* a[15] +=  t[7]        = r[7] */
         "ADD	r0, sp, #0x30\n\t"
-        "LDM	r0, {r1, r2, r3, r4}\n\t"
+        "ldm   r0, {r1, r2, r3, r4}\n\t"
         "ADDS	lr, lr, #0x-1\n\t"
         "ADCS	r1, r1, r9\n\t"
         "ADCS	r2, r2, r10\n\t"
@@ -3724,7 +3755,7 @@ static void sp_256_mont_sqr_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit
         /* a[5]  += -t[2]        = t[5] */
         /* a[6]  += -t[3]        = t[6] */
         "ADD	r0, sp, #0xc\n\t"
-        "LDM	r0, {r0, r1, r2, r3}\n\t"
+        "ldm   r0, {r0, r1, r2, r3}\n\t"
         "SUBS	r0, r0, r5\n\t"
         "SBCS	r1, r1, r6\n\t"
         "SBCS	r2, r2, r7\n\t"
@@ -3734,7 +3765,7 @@ static void sp_256_mont_sqr_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit
         /* a[9]  += -t[6] - t[2] = r[1] */
         /* a[10] += -t[7] - t[3] = r[2] */
         "ADD	r0, sp, #0x1c\n\t"
-        "LDM	r0, {r0, r1, r2, r3}\n\t"
+        "ldm   r0, {r0, r1, r2, r3}\n\t"
         "SBCS	r0, r0, r9\n\t"
         "SBCS	r1, r1, r10\n\t"
         "SBCS	r2, r2, r11\n\t"
@@ -3752,7 +3783,7 @@ static void sp_256_mont_sqr_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit
         /* a[14] +=       - t[7] = r[6] */
         /* a[15] +=              = r[7] */
         "ADD	r0, sp, #0x2c\n\t"
-        "LDM	r0, {r4, r5, r6, r7, r8}\n\t"
+        "ldm   r0, {r4, r5, r6, r7, r8}\n\t"
         "RSB	lr, lr, #0x0\n\t"
         "SUBS	r4, r4, lr\n\t"
         "SBCS	r5, r5, #0x0\n\t"
@@ -3784,7 +3815,8 @@ static void sp_256_mont_sqr_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit
         "ADD	sp, sp, #0x44\n\t"
         : [r] "+r" (r), [a] "+r" (a)
         :
-        : "memory", "r2", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12", "lr", "cc"
+        : "memory", "cc", "r2", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10",
+            "r11", "r12", "lr"
     );
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     (void)m_p;
@@ -3925,9 +3957,11 @@ static void sp_256_mont_inv_sm2_8(sp_digit* r, const sp_digit* a, sp_digit* td)
  * mp  The digit representing the negative inverse of m mod 2^n.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_256_mont_reduce_sm2_8(sp_digit* a_p, const sp_digit* m_p, sp_digit mp_p)
+SP_NOINLINE static void sp_256_mont_reduce_sm2_8(sp_digit* a_p,
+    const sp_digit* m_p, sp_digit mp_p)
 #else
-SP_NOINLINE static void sp_256_mont_reduce_sm2_8(sp_digit* a, const sp_digit* m, sp_digit mp)
+SP_NOINLINE static void sp_256_mont_reduce_sm2_8(sp_digit* a, const sp_digit* m,
+    sp_digit mp)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -4031,7 +4065,8 @@ SP_NOINLINE static void sp_256_mont_reduce_sm2_8(sp_digit* a, const sp_digit* m,
         "MOV	%[mp], r3\n\t"
         : [a] "+r" (a), [m] "+r" (m), [mp] "+r" (mp)
         :
-        : "memory", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12", "lr", "cc"
+        : "memory", "cc", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10",
+            "r11", "r12", "lr"
     );
     sp_256_cond_sub_sm2_8(a - 8, a, m, (sp_digit)0 - mp);
 }
@@ -4044,9 +4079,11 @@ SP_NOINLINE static void sp_256_mont_reduce_sm2_8(sp_digit* a, const sp_digit* m,
  * mp  The digit representing the negative inverse of m mod 2^n.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_256_mont_reduce_sm2_8(sp_digit* a_p, const sp_digit* m_p, sp_digit mp_p)
+SP_NOINLINE static void sp_256_mont_reduce_sm2_8(sp_digit* a_p,
+    const sp_digit* m_p, sp_digit mp_p)
 #else
-SP_NOINLINE static void sp_256_mont_reduce_sm2_8(sp_digit* a, const sp_digit* m, sp_digit mp)
+SP_NOINLINE static void sp_256_mont_reduce_sm2_8(sp_digit* a, const sp_digit* m,
+    sp_digit mp)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -4132,7 +4169,8 @@ SP_NOINLINE static void sp_256_mont_reduce_sm2_8(sp_digit* a, const sp_digit* m,
         "MOV	%[mp], r5\n\t"
         : [a] "+r" (a), [m] "+r" (m), [mp] "+r" (mp)
         :
-        : "memory", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12", "lr", "cc"
+        : "memory", "cc", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10",
+            "r11", "r12", "lr"
     );
     sp_256_cond_sub_sm2_8(a - 8, a, m, (sp_digit)0 - mp);
 }
@@ -4146,9 +4184,11 @@ SP_NOINLINE static void sp_256_mont_reduce_sm2_8(sp_digit* a, const sp_digit* m,
  * mp  The digit representing the negative inverse of m mod 2^n.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_256_mont_reduce_sm2_8(sp_digit* a_p, const sp_digit* m_p, sp_digit mp_p)
+static void sp_256_mont_reduce_sm2_8(sp_digit* a_p, const sp_digit* m_p,
+    sp_digit mp_p)
 #else
-static void sp_256_mont_reduce_sm2_8(sp_digit* a, const sp_digit* m, sp_digit mp)
+static void sp_256_mont_reduce_sm2_8(sp_digit* a, const sp_digit* m,
+    sp_digit mp)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -4159,12 +4199,12 @@ static void sp_256_mont_reduce_sm2_8(sp_digit* a, const sp_digit* m, sp_digit mp
         "SUB	sp, sp, #0x44\n\t"
         "STR	%[a], [sp, #64]\n\t"
         "MOV	lr, sp\n\t"
-        "LDM	%[a]!, {r1, r2, r3, r4, r5, r6, r7, r8}\n\t"
+        "ldm   %[a]!, {r1, r2, r3, r4, r5, r6, r7, r8}\n\t"
         "STM	lr!, {r1, r2, r3, r4, r5, r6, r7, r8}\n\t"
-        "LDM	%[a], {r1, r2, r3, r4, r5, r6, r7, r8}\n\t"
+        "ldm   %[a], {r1, r2, r3, r4, r5, r6, r7, r8}\n\t"
         "STM	lr, {r1, r2, r3, r4, r5, r6, r7, r8}\n\t"
         /* Start Reduction */
-        "LDM	sp, {r5, r6, r7, r8, r9, r10, r11, r12}\n\t"
+        "ldm   sp, {r5, r6, r7, r8, r9, r10, r11, r12}\n\t"
         "MOV	r3, r11\n\t"
         "MOV	r4, r12\n\t"
         /* mu = a[0..7] + a[0..5] << 64 - a[0..4] << 96 */
@@ -4226,7 +4266,7 @@ static void sp_256_mont_reduce_sm2_8(sp_digit* a, const sp_digit* m, sp_digit mp
         /* a[10] +=  t[2]        = r[2] + t[7] + t[3] */
         /* a[11] +=  t[3]        = r[3] +        t[4] */
         "ADD	r0, sp, #0x20\n\t"
-        "LDM	r0, {r1, r2, r3, r4}\n\t"
+        "ldm   r0, {r1, r2, r3, r4}\n\t"
         "ADCS	r1, r1, r5\n\t"
         "ADCS	r2, r2, r6\n\t"
         "ADCS	r3, r3, r7\n\t"
@@ -4244,7 +4284,7 @@ static void sp_256_mont_reduce_sm2_8(sp_digit* a, const sp_digit* m, sp_digit mp
         /* a[14] +=  t[6]        = r[6] +        t[7] */
         /* a[15] +=  t[7]        = r[7] */
         "ADD	r0, sp, #0x30\n\t"
-        "LDM	r0, {r1, r2, r3, r4}\n\t"
+        "ldm   r0, {r1, r2, r3, r4}\n\t"
         "ADDS	lr, lr, #0x-1\n\t"
         "ADCS	r1, r1, r9\n\t"
         "ADCS	r2, r2, r10\n\t"
@@ -4259,7 +4299,7 @@ static void sp_256_mont_reduce_sm2_8(sp_digit* a, const sp_digit* m, sp_digit mp
         /* a[5]  += -t[2]        = t[5] */
         /* a[6]  += -t[3]        = t[6] */
         "ADD	r0, sp, #0xc\n\t"
-        "LDM	r0, {r0, r1, r2, r3}\n\t"
+        "ldm   r0, {r0, r1, r2, r3}\n\t"
         "SUBS	r0, r0, r5\n\t"
         "SBCS	r1, r1, r6\n\t"
         "SBCS	r2, r2, r7\n\t"
@@ -4269,7 +4309,7 @@ static void sp_256_mont_reduce_sm2_8(sp_digit* a, const sp_digit* m, sp_digit mp
         /* a[9]  += -t[6] - t[2] = r[1] */
         /* a[10] += -t[7] - t[3] = r[2] */
         "ADD	r0, sp, #0x1c\n\t"
-        "LDM	r0, {r0, r1, r2, r3}\n\t"
+        "ldm   r0, {r0, r1, r2, r3}\n\t"
         "SBCS	r0, r0, r9\n\t"
         "SBCS	r1, r1, r10\n\t"
         "SBCS	r2, r2, r11\n\t"
@@ -4287,7 +4327,7 @@ static void sp_256_mont_reduce_sm2_8(sp_digit* a, const sp_digit* m, sp_digit mp
         /* a[14] +=       - t[7] = r[6] */
         /* a[15] +=              = r[7] */
         "ADD	r0, sp, #0x2c\n\t"
-        "LDM	r0, {r4, r5, r6, r7, r8}\n\t"
+        "ldm   r0, {r4, r5, r6, r7, r8}\n\t"
         "RSB	lr, lr, #0x0\n\t"
         "SUBS	r4, r4, lr\n\t"
         "SBCS	r5, r5, #0x0\n\t"
@@ -4319,7 +4359,8 @@ static void sp_256_mont_reduce_sm2_8(sp_digit* a, const sp_digit* m, sp_digit mp
         "ADD	sp, sp, #0x44\n\t"
         : [a] "+r" (a)
         :
-        : "memory", "r1", "r2", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12", "lr", "cc"
+        : "memory", "cc", "r1", "r2", "r3", "r4", "r5", "r6", "r7", "r8", "r9",
+            "r10", "r11", "r12", "lr"
     );
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     (void)m_p;
@@ -4341,9 +4382,11 @@ static void sp_256_mont_reduce_sm2_8(sp_digit* a, const sp_digit* m, sp_digit mp
  * mp  The digit representing the negative inverse of m mod 2^n.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_256_mont_reduce_order_sm2_8(sp_digit* a_p, const sp_digit* m_p, sp_digit mp_p)
+SP_NOINLINE static void sp_256_mont_reduce_order_sm2_8(sp_digit* a_p,
+    const sp_digit* m_p, sp_digit mp_p)
 #else
-SP_NOINLINE static void sp_256_mont_reduce_order_sm2_8(sp_digit* a, const sp_digit* m, sp_digit mp)
+SP_NOINLINE static void sp_256_mont_reduce_order_sm2_8(sp_digit* a,
+    const sp_digit* m, sp_digit mp)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -4447,7 +4490,8 @@ SP_NOINLINE static void sp_256_mont_reduce_order_sm2_8(sp_digit* a, const sp_dig
         "MOV	%[mp], r3\n\t"
         : [a] "+r" (a), [m] "+r" (m), [mp] "+r" (mp)
         :
-        : "memory", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12", "lr", "cc"
+        : "memory", "cc", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10",
+            "r11", "r12", "lr"
     );
     sp_256_cond_sub_sm2_8(a - 8, a, m, (sp_digit)0 - mp);
 }
@@ -4460,9 +4504,11 @@ SP_NOINLINE static void sp_256_mont_reduce_order_sm2_8(sp_digit* a, const sp_dig
  * mp  The digit representing the negative inverse of m mod 2^n.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_256_mont_reduce_order_sm2_8(sp_digit* a_p, const sp_digit* m_p, sp_digit mp_p)
+SP_NOINLINE static void sp_256_mont_reduce_order_sm2_8(sp_digit* a_p,
+    const sp_digit* m_p, sp_digit mp_p)
 #else
-SP_NOINLINE static void sp_256_mont_reduce_order_sm2_8(sp_digit* a, const sp_digit* m, sp_digit mp)
+SP_NOINLINE static void sp_256_mont_reduce_order_sm2_8(sp_digit* a,
+    const sp_digit* m, sp_digit mp)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -4548,7 +4594,8 @@ SP_NOINLINE static void sp_256_mont_reduce_order_sm2_8(sp_digit* a, const sp_dig
         "MOV	%[mp], r5\n\t"
         : [a] "+r" (a), [m] "+r" (m), [mp] "+r" (mp)
         :
-        : "memory", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12", "lr", "cc"
+        : "memory", "cc", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10",
+            "r11", "r12", "lr"
     );
     sp_256_cond_sub_sm2_8(a - 8, a, m, (sp_digit)0 - mp);
 }
@@ -4603,9 +4650,11 @@ static void sp_256_map_sm2_8(sp_point_256* r, const sp_point_256* p,
  * m   Modulus (prime).
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_256_mont_add_sm2_8(sp_digit* r_p, const sp_digit* a_p, const sp_digit* b_p, const sp_digit* m_p)
+SP_NOINLINE static void sp_256_mont_add_sm2_8(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p, const sp_digit* m_p)
 #else
-SP_NOINLINE static void sp_256_mont_add_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit* b, const sp_digit* m)
+SP_NOINLINE static void sp_256_mont_add_sm2_8(sp_digit* r, const sp_digit* a,
+    const sp_digit* b, const sp_digit* m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -4616,7 +4665,7 @@ SP_NOINLINE static void sp_256_mont_add_sm2_8(sp_digit* r, const sp_digit* a, co
 
     __asm__ __volatile__ (
         "MOV	lr, #0x0\n\t"
-        "LDM	%[a], {r5, r6, r7, r8, r9, r10, r11, r12}\n\t"
+        "ldm   %[a], {r5, r6, r7, r8, r9, r10, r11, r12}\n\t"
         "LDM	%[b]!, {r3, r4}\n\t"
         "ADDS	r5, r5, r3\n\t"
         "ADCS	r6, r6, r4\n\t"
@@ -4652,7 +4701,8 @@ SP_NOINLINE static void sp_256_mont_add_sm2_8(sp_digit* r, const sp_digit* a, co
         "STM	%[r], {r5, r6, r7, r8, r9, r10, r11, r12}\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
         :
-        : "memory", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12", "lr", "cc"
+        : "memory", "cc", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10",
+            "r11", "r12", "lr"
     );
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     (void)m_p;
@@ -4668,9 +4718,11 @@ SP_NOINLINE static void sp_256_mont_add_sm2_8(sp_digit* r, const sp_digit* a, co
  * m   Modulus (prime).
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_256_mont_dbl_sm2_8(sp_digit* r_p, const sp_digit* a_p, const sp_digit* m_p)
+SP_NOINLINE static void sp_256_mont_dbl_sm2_8(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* m_p)
 #else
-SP_NOINLINE static void sp_256_mont_dbl_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit* m)
+SP_NOINLINE static void sp_256_mont_dbl_sm2_8(sp_digit* r, const sp_digit* a,
+    const sp_digit* m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -4680,7 +4732,7 @@ SP_NOINLINE static void sp_256_mont_dbl_sm2_8(sp_digit* r, const sp_digit* a, co
 
     __asm__ __volatile__ (
         "MOV	r2, #0x0\n\t"
-        "LDM	%[a], {r4, r5, r6, r7, r8, r9, r10, r11}\n\t"
+        "ldm   %[a], {r4, r5, r6, r7, r8, r9, r10, r11}\n\t"
         "ADDS	r4, r4, r4\n\t"
         "ADCS	r5, r5, r5\n\t"
         "ADCS	r6, r6, r6\n\t"
@@ -4712,7 +4764,8 @@ SP_NOINLINE static void sp_256_mont_dbl_sm2_8(sp_digit* r, const sp_digit* a, co
         "STM	%[r], {r4, r5, r6, r7, r8, r9, r10, r11}\n\t"
         : [r] "+r" (r), [a] "+r" (a)
         :
-        : "memory", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r2", "cc"
+        : "memory", "cc", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11",
+            "r2"
     );
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     (void)m_p;
@@ -4728,9 +4781,11 @@ SP_NOINLINE static void sp_256_mont_dbl_sm2_8(sp_digit* r, const sp_digit* a, co
  * m   Modulus (prime).
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_256_mont_tpl_sm2_8(sp_digit* r_p, const sp_digit* a_p, const sp_digit* m_p)
+SP_NOINLINE static void sp_256_mont_tpl_sm2_8(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* m_p)
 #else
-SP_NOINLINE static void sp_256_mont_tpl_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit* m)
+SP_NOINLINE static void sp_256_mont_tpl_sm2_8(sp_digit* r, const sp_digit* a,
+    const sp_digit* m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -4740,7 +4795,7 @@ SP_NOINLINE static void sp_256_mont_tpl_sm2_8(sp_digit* r, const sp_digit* a, co
 
     __asm__ __volatile__ (
         "MOV	r12, #0x0\n\t"
-        "LDM	%[a], {r4, r5, r6, r7, r8, r9, r10, r11}\n\t"
+        "ldm   %[a], {r4, r5, r6, r7, r8, r9, r10, r11}\n\t"
         "ADDS	r4, r4, r4\n\t"
         "ADCS	r5, r5, r5\n\t"
         "ADCS	r6, r6, r6\n\t"
@@ -4804,7 +4859,8 @@ SP_NOINLINE static void sp_256_mont_tpl_sm2_8(sp_digit* r, const sp_digit* a, co
         "STM	%[r], {r4, r5, r6, r7, r8, r9, r10, r11}\n\t"
         : [r] "+r" (r), [a] "+r" (a)
         :
-        : "memory", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r2", "r3", "r12", "cc"
+        : "memory", "cc", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11",
+            "r2", "r3", "r12"
     );
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     (void)m_p;
@@ -4821,9 +4877,11 @@ SP_NOINLINE static void sp_256_mont_tpl_sm2_8(sp_digit* r, const sp_digit* a, co
  * m   Modulus (prime).
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-SP_NOINLINE static void sp_256_mont_sub_sm2_8(sp_digit* r_p, const sp_digit* a_p, const sp_digit* b_p, const sp_digit* m_p)
+SP_NOINLINE static void sp_256_mont_sub_sm2_8(sp_digit* r_p,
+    const sp_digit* a_p, const sp_digit* b_p, const sp_digit* m_p)
 #else
-SP_NOINLINE static void sp_256_mont_sub_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit* b, const sp_digit* m)
+SP_NOINLINE static void sp_256_mont_sub_sm2_8(sp_digit* r, const sp_digit* a,
+    const sp_digit* b, const sp_digit* m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -4834,7 +4892,7 @@ SP_NOINLINE static void sp_256_mont_sub_sm2_8(sp_digit* r, const sp_digit* a, co
 
     __asm__ __volatile__ (
         "MOV	lr, #0x0\n\t"
-        "LDM	%[a], {r5, r6, r7, r8, r9, r10, r11, r12}\n\t"
+        "ldm   %[a], {r5, r6, r7, r8, r9, r10, r11, r12}\n\t"
         "LDM	%[b]!, {r3, r4}\n\t"
         "SUBS	r5, r5, r3\n\t"
         "SBCS	r6, r6, r4\n\t"
@@ -4868,7 +4926,8 @@ SP_NOINLINE static void sp_256_mont_sub_sm2_8(sp_digit* r, const sp_digit* a, co
         "STM	%[r], {r5, r6, r7, r8, r9, r10, r11, r12}\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
         :
-        : "memory", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12", "lr", "cc"
+        : "memory", "cc", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10",
+            "r11", "r12", "lr"
     );
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
     (void)m_p;
@@ -4884,9 +4943,11 @@ SP_NOINLINE static void sp_256_mont_sub_sm2_8(sp_digit* r, const sp_digit* a, co
  * m  Modulus (prime).
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static void sp_256_mont_div2_sm2_8(sp_digit* r_p, const sp_digit* a_p, const sp_digit* m_p)
+static void sp_256_mont_div2_sm2_8(sp_digit* r_p, const sp_digit* a_p,
+    const sp_digit* m_p)
 #else
-static void sp_256_mont_div2_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit* m)
+static void sp_256_mont_div2_sm2_8(sp_digit* r, const sp_digit* a,
+    const sp_digit* m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -4896,7 +4957,7 @@ static void sp_256_mont_div2_sm2_8(sp_digit* r, const sp_digit* a, const sp_digi
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 
     __asm__ __volatile__ (
-        "LDM	%[a], {r4, r5, r6, r7}\n\t"
+        "ldm   %[a], {r4, r5, r6, r7}\n\t"
         "AND	r3, r4, #0x1\n\t"
         "RSB	r8, r3, #0x0\n\t"
         "ADDS	r4, r4, r8\n\t"
@@ -4923,7 +4984,7 @@ static void sp_256_mont_div2_sm2_8(sp_digit* r, const sp_digit* a, const sp_digi
         "MOV	r3, r4\n\t"
         "STRD	r8, r9, [%[r], #16]\n\t"
         "STRD	r10, r11, [%[r], #24]\n\t"
-        "LDM	%[r], {r4, r5, r6, r7}\n\t"
+        "ldm   %[r], {r4, r5, r6, r7}\n\t"
         "LSR	r8, r4, #1\n\t"
         "LSR	r9, r5, #1\n\t"
         "LSR	r10, r6, #1\n\t"
@@ -4935,7 +4996,8 @@ static void sp_256_mont_div2_sm2_8(sp_digit* r, const sp_digit* a, const sp_digi
         "STM	%[r], {r8, r9, r10, r11}\n\t"
         : [r] "+r" (r), [a] "+r" (a), [m] "+r" (m)
         :
-        : "memory", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r3", "cc"
+        : "memory", "cc", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11",
+            "r3"
     );
 }
 
@@ -6186,7 +6248,7 @@ typedef struct sp_cache_256_t {
     /* Precomputation table for point. */
     sp_table_entry_256 table[16];
     /* Count of entries in table. */
-    uint32_t cnt;
+    word32 cnt;
     /* Point and table set in entry. */
     int set;
 } sp_cache_256_t;
@@ -6214,7 +6276,7 @@ static void sp_ecc_get_cache_256(const sp_point_256* g, sp_cache_256_t** cache)
 {
     int i;
     int j;
-    uint32_t least;
+    word32 least;
 
     if (sp_cache_256_inited == 0) {
         for (i=0; i<FP_ENTRIES; i++) {
@@ -6607,7 +6669,7 @@ typedef struct sp_cache_256_t {
     /* Precomputation table for point. */
     sp_table_entry_256 table[256];
     /* Count of entries in table. */
-    uint32_t cnt;
+    word32 cnt;
     /* Point and table set in entry. */
     int set;
 } sp_cache_256_t;
@@ -6635,7 +6697,7 @@ static void sp_ecc_get_cache_256(const sp_point_256* g, sp_cache_256_t** cache)
 {
     int i;
     int j;
-    uint32_t least;
+    word32 least;
 
     if (sp_cache_256_inited == 0) {
         for (i=0; i<FP_ENTRIES; i++) {
@@ -8452,13 +8514,13 @@ static void sp_256_add_one_sm2_8(sp_digit* a)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 
     __asm__ __volatile__ (
-        "LDM	%[a], {r1, r2, r3, r4}\n\t"
+        "ldm   %[a], {r1, r2, r3, r4}\n\t"
         "ADDS	r1, r1, #0x1\n\t"
         "ADCS	r2, r2, #0x0\n\t"
         "ADCS	r3, r3, #0x0\n\t"
         "ADCS	r4, r4, #0x0\n\t"
         "STM	%[a]!, {r1, r2, r3, r4}\n\t"
-        "LDM	%[a], {r1, r2, r3, r4}\n\t"
+        "ldm   %[a], {r1, r2, r3, r4}\n\t"
         "ADCS	r1, r1, #0x0\n\t"
         "ADCS	r2, r2, #0x0\n\t"
         "ADCS	r3, r3, #0x0\n\t"
@@ -8466,7 +8528,7 @@ static void sp_256_add_one_sm2_8(sp_digit* a)
         "STM	%[a]!, {r1, r2, r3, r4}\n\t"
         : [a] "+r" (a)
         :
-        : "memory", "r1", "r2", "r3", "r4", "cc"
+        : "memory", "cc", "r1", "r2", "r3", "r4"
     );
 }
 
@@ -8483,7 +8545,8 @@ static void sp_256_from_bin(sp_digit* r, int size, const byte* a, int n)
     int j;
     byte* d;
 
-    for (i = n - 1,j = 0; i >= 3; i -= 4) {
+    j = 0;
+    for (i = n - 1; i >= 3; i -= 4) {
         r[j]  = ((sp_digit)a[i - 0] <<  0) |
                 ((sp_digit)a[i - 1] <<  8) |
                 ((sp_digit)a[i - 2] << 16) |
@@ -8494,12 +8557,20 @@ static void sp_256_from_bin(sp_digit* r, int size, const byte* a, int n)
     if (i >= 0) {
         r[j] = 0;
 
-        d = (byte*)r;
+        d = (byte*)(r + j);
+#ifdef BIG_ENDIAN_ORDER
         switch (i) {
-            case 2: d[n - 1 - 2] = a[2]; //fallthrough
-            case 1: d[n - 1 - 1] = a[1]; //fallthrough
-            case 0: d[n - 1 - 0] = a[0]; //fallthrough
+            case 2: d[1] = *(a++); //fallthrough
+            case 1: d[2] = *(a++); //fallthrough
+            case 0: d[3] = *a    ; //fallthrough
         }
+#else
+        switch (i) {
+            case 2: d[2] = a[2]; //fallthrough
+            case 1: d[1] = a[1]; //fallthrough
+            case 0: d[0] = a[0]; //fallthrough
+        }
+#endif
         j++;
     }
 
@@ -8844,9 +8915,11 @@ int sp_ecc_secret_gen_256_nb(sp_ecc_ctx_t* sp_ctx, const mp_int* priv,
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_256_sub_sm2_8(sp_digit* r_p, const sp_digit* a_p, const sp_digit* b_p)
+static sp_digit sp_256_sub_sm2_8(sp_digit* r_p, const sp_digit* a_p,
+    const sp_digit* b_p)
 #else
-static sp_digit sp_256_sub_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit* b)
+static sp_digit sp_256_sub_sm2_8(sp_digit* r, const sp_digit* a,
+    const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -8884,9 +8957,10 @@ static sp_digit sp_256_sub_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit*
         "MOV	%[r], r11\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
         :
-        : "memory", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12", "cc"
+        : "memory", "cc", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10",
+            "r11", "r12"
     );
-    return (uint32_t)(size_t)r;
+    return (word32)(size_t)r;
 }
 
 #else
@@ -8897,9 +8971,11 @@ static sp_digit sp_256_sub_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit*
  * b  A single precision integer.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_256_sub_sm2_8(sp_digit* r_p, const sp_digit* a_p, const sp_digit* b_p)
+static sp_digit sp_256_sub_sm2_8(sp_digit* r_p, const sp_digit* a_p,
+    const sp_digit* b_p)
 #else
-static sp_digit sp_256_sub_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit* b)
+static sp_digit sp_256_sub_sm2_8(sp_digit* r, const sp_digit* a,
+    const sp_digit* b)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -8926,9 +9002,9 @@ static sp_digit sp_256_sub_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit*
         "SBC	%[r], r6, r6\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b)
         :
-        : "memory", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "cc"
+        : "memory", "cc", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10"
     );
-    return (uint32_t)(size_t)r;
+    return (word32)(size_t)r;
 }
 
 #endif /* WOLFSSL_SP_SMALL */
@@ -8945,9 +9021,11 @@ static sp_digit sp_256_sub_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit*
  * m  Mask value to apply.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_256_cond_add_sm2_8(sp_digit* r_p, const sp_digit* a_p, const sp_digit* b_p, sp_digit m_p)
+static sp_digit sp_256_cond_add_sm2_8(sp_digit* r_p, const sp_digit* a_p,
+    const sp_digit* b_p, sp_digit m_p)
 #else
-static sp_digit sp_256_cond_add_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit* b, sp_digit m)
+static sp_digit sp_256_cond_add_sm2_8(sp_digit* r, const sp_digit* a,
+    const sp_digit* b, sp_digit m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -8986,9 +9064,9 @@ static sp_digit sp_256_cond_add_sm2_8(sp_digit* r, const sp_digit* a, const sp_d
         "MOV	%[r], r5\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b), [m] "+r" (m)
         :
-        : "memory", "r4", "r5", "r6", "r7", "r8", "cc"
+        : "memory", "cc", "r4", "r5", "r6", "r7", "r8"
     );
-    return (uint32_t)(size_t)r;
+    return (word32)(size_t)r;
 }
 
 #else
@@ -9001,9 +9079,11 @@ static sp_digit sp_256_cond_add_sm2_8(sp_digit* r, const sp_digit* a, const sp_d
  * m  Mask value to apply.
  */
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
-static sp_digit sp_256_cond_add_sm2_8(sp_digit* r_p, const sp_digit* a_p, const sp_digit* b_p, sp_digit m_p)
+static sp_digit sp_256_cond_add_sm2_8(sp_digit* r_p, const sp_digit* a_p,
+    const sp_digit* b_p, sp_digit m_p)
 #else
-static sp_digit sp_256_cond_add_sm2_8(sp_digit* r, const sp_digit* a, const sp_digit* b, sp_digit m)
+static sp_digit sp_256_cond_add_sm2_8(sp_digit* r, const sp_digit* a,
+    const sp_digit* b, sp_digit m)
 #endif /* !WOLFSSL_NO_VAR_ASSIGN_REG */
 {
 #ifndef WOLFSSL_NO_VAR_ASSIGN_REG
@@ -9046,9 +9126,9 @@ static sp_digit sp_256_cond_add_sm2_8(sp_digit* r, const sp_digit* a, const sp_d
         "ADC	%[r], r10, r10\n\t"
         : [r] "+r" (r), [a] "+r" (a), [b] "+r" (b), [m] "+r" (m)
         :
-        : "memory", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "cc"
+        : "memory", "cc", "r4", "r5", "r6", "r7", "r8", "r9", "r10"
     );
-    return (uint32_t)(size_t)r;
+    return (word32)(size_t)r;
 }
 
 #endif /* WOLFSSL_SP_SMALL */
@@ -9953,7 +10033,7 @@ int sp_ecc_map_sm2_256(mp_int* pX, mp_int* pY, mp_int* pZ)
 #endif /* WOLFSSL_PUBLIC_ECC_ADD_DBL */
 #ifdef HAVE_COMP_KEY
 /* Square root power for the P256 curve. */
-static const uint32_t p256_sm2_sqrt_power[8] = {
+static const word32 p256_sm2_sqrt_power[8] = {
     0x00000000,0x40000000,0xc0000000,0xffffffff,0xffffffff,0xffffffff,
     0xbfffffff,0x3fffffff
 };

--- a/sp_sm2_x86_64.c
+++ b/sp_sm2_x86_64.c
@@ -1,6 +1,6 @@
 /* sp.c
  *
- * Copyright (C) 2006-2024 wolfSSL Inc.
+ * Copyright (C) 2006-2025 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *
@@ -21,16 +21,11 @@
 
 /* Implementation by Sean Parkinson. */
 
-#ifdef HAVE_CONFIG_H
-    #include <config.h>
-#endif
-
-#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/libwolfssl_sources.h>
 
 #if defined(WOLFSSL_HAVE_SP_RSA) || defined(WOLFSSL_HAVE_SP_DH) || \
     defined(WOLFSSL_HAVE_SP_ECC)
 
-#include <wolfssl/wolfcrypt/error-crypt.h>
 #include <wolfssl/wolfcrypt/cpuid.h>
 #ifdef NO_INLINE
     #include <wolfssl/wolfcrypt/misc.h>
@@ -1584,13 +1579,13 @@ static void sp_256_proj_point_add_sub_sm2_4(sp_point_256* ra,
 /* Structure used to describe recoding of scalar multiplication. */
 typedef struct ecc_recode_256 {
     /* Index into pre-computation table. */
-    uint8_t i;
+    word8 i;
     /* Use the negative of the point. */
-    uint8_t neg;
+    word8 neg;
 } ecc_recode_256;
 
 /* The index into pre-computation table to use. */
-static const uint8_t recode_index_4_6[66] = {
+static const word8 recode_index_4_6[66] = {
      0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15,
     16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
     32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17,
@@ -1599,7 +1594,7 @@ static const uint8_t recode_index_4_6[66] = {
 };
 
 /* Whether to negate y-ordinate. */
-static const uint8_t recode_neg_4_6[66] = {
+static const word8 recode_neg_4_6[66] = {
      0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
      0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
      1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
@@ -1617,7 +1612,7 @@ static void sp_256_ecc_recode_6_4(const sp_digit* k, ecc_recode_256* v)
 {
     int i;
     int j;
-    uint8_t y;
+    word8 y;
     int carry = 0;
     int o;
     sp_digit n;
@@ -1626,7 +1621,7 @@ static void sp_256_ecc_recode_6_4(const sp_digit* k, ecc_recode_256* v)
     n = k[j];
     o = 0;
     for (i=0; i<43; i++) {
-        y = (uint8_t)(int8_t)n;
+        y = (word8)(int8_t)n;
         if (o + 6 < 64) {
             y &= 0x3f;
             n >>= 6;
@@ -1640,12 +1635,12 @@ static void sp_256_ecc_recode_6_4(const sp_digit* k, ecc_recode_256* v)
         }
         else if (++j < 4) {
             n = k[j];
-            y |= (uint8_t)((n << (64 - o)) & 0x3f);
+            y |= (word8)((n << (64 - o)) & 0x3f);
             o -= 58;
             n >>= o;
         }
 
-        y += (uint8_t)carry;
+        y = (word8)(y + carry);
         v[i].i = recode_index_4_6[y];
         v[i].neg = recode_neg_4_6[y];
         carry = (y >> 6) + v[i].neg;
@@ -3206,7 +3201,7 @@ typedef struct sp_cache_256_t {
     /* Precomputation table for point. */
     sp_table_entry_256 table[64];
     /* Count of entries in table. */
-    uint32_t cnt;
+    word32 cnt;
     /* Point and table set in entry. */
     int set;
 } sp_cache_256_t;
@@ -3234,7 +3229,7 @@ static void sp_ecc_get_cache_256(const sp_point_256* g, sp_cache_256_t** cache)
 {
     int i;
     int j;
-    uint32_t least;
+    word32 least;
 
     if (sp_cache_256_inited == 0) {
         for (i=0; i<FP_ENTRIES; i++) {
@@ -4277,7 +4272,7 @@ static int sp_256_ecc_mulmod_base_avx2_sm2_4(sp_point_256* r, const sp_digit* k,
 #endif /* HAVE_INTEL_AVX2 */
 #else /* WOLFSSL_SP_SMALL */
 /* The index into pre-computation table to use. */
-static const uint8_t recode_index_4_7[130] = {
+static const word8 recode_index_4_7[130] = {
      0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15,
     16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
     32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47,
@@ -4290,7 +4285,7 @@ static const uint8_t recode_index_4_7[130] = {
 };
 
 /* Whether to negate y-ordinate. */
-static const uint8_t recode_neg_4_7[130] = {
+static const word8 recode_neg_4_7[130] = {
      0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
      0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
      0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
@@ -4312,7 +4307,7 @@ static void sp_256_ecc_recode_7_4(const sp_digit* k, ecc_recode_256* v)
 {
     int i;
     int j;
-    uint8_t y;
+    word8 y;
     int carry = 0;
     int o;
     sp_digit n;
@@ -4321,7 +4316,7 @@ static void sp_256_ecc_recode_7_4(const sp_digit* k, ecc_recode_256* v)
     n = k[j];
     o = 0;
     for (i=0; i<37; i++) {
-        y = (uint8_t)(int8_t)n;
+        y = (word8)(int8_t)n;
         if (o + 7 < 64) {
             y &= 0x7f;
             n >>= 7;
@@ -4335,12 +4330,12 @@ static void sp_256_ecc_recode_7_4(const sp_digit* k, ecc_recode_256* v)
         }
         else if (++j < 4) {
             n = k[j];
-            y |= (uint8_t)((n << (64 - o)) & 0x7f);
+            y |= (word8)((n << (64 - o)) & 0x7f);
             o -= 57;
             n >>= o;
         }
 
-        y += (uint8_t)carry;
+        y = (word8)(y + carry);
         v[i].i = recode_index_4_7[y];
         v[i].neg = recode_neg_4_7[y];
         carry = (y >> 7) + v[i].neg;
@@ -16403,7 +16398,7 @@ static int sp_256_ecc_mulmod_add_only_sm2_4(sp_point_256* r, const sp_point_256*
             p->infinity = !v[i].i;
             sp_256_sub_sm2_4(negy, p256_sm2_mod, p->y);
             sp_256_norm_4(negy);
-            sp_256_cond_copy_sm2_4(p->y, negy, 0 - v[i].neg);
+            sp_256_cond_copy_sm2_4(p->y, negy, (sp_digit)(0 - v[i].neg));
             sp_256_proj_point_add_qz1_sm2_4(rt, rt, p, tmp);
         }
         if (map != 0) {
@@ -16536,7 +16531,7 @@ static int sp_256_ecc_mulmod_add_only_avx2_sm2_4(sp_point_256* r, const sp_point
             p->infinity = !v[i].i;
             sp_256_sub_sm2_4(negy, p256_sm2_mod, p->y);
             sp_256_norm_4(negy);
-            sp_256_cond_copy_sm2_4(p->y, negy, 0 - v[i].neg);
+            sp_256_cond_copy_sm2_4(p->y, negy, (sp_digit)(0 - v[i].neg));
             sp_256_proj_point_add_qz1_avx2_sm2_4(rt, rt, p, tmp);
         }
         if (map != 0) {
@@ -18324,7 +18319,7 @@ int sp_ecc_map_sm2_256(mp_int* pX, mp_int* pY, mp_int* pZ)
 #endif /* WOLFSSL_PUBLIC_ECC_ADD_DBL */
 #ifdef HAVE_COMP_KEY
 /* Square root power for the P256 curve. */
-static const uint64_t p256_sm2_sqrt_power[4] = {
+static const word64 p256_sm2_sqrt_power[4] = {
     0x4000000000000000,0xffffffffc0000000,0xffffffffffffffff,
     0x3fffffffbfffffff
 };

--- a/sp_sm2_x86_64_asm.S
+++ b/sp_sm2_x86_64_asm.S
@@ -1,6 +1,6 @@
 /* sp_sm2_x86_64_asm.S */
 /*
- * Copyright (C) 2006-2024 wolfSSL Inc.
+ * Copyright (C) 2006-2025 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *
@@ -42,7 +42,9 @@
 #define HAVE_INTEL_AVX1
 #endif /* HAVE_INTEL_AVX1 */
 #ifndef NO_AVX2_SUPPORT
+#ifndef HAVE_INTEL_AVX2
 #define HAVE_INTEL_AVX2
+#endif /* HAVE_INTEL_AVX2 */
 #endif /* NO_AVX2_SUPPORT */
 
 #ifdef WOLFSSL_SP_X86_64_ASM


### PR DESCRIPTION
regenerate with `./gen-asm.sh` using current `master` scripts (94ce81048a), and include `libwolfssl_sources.h` in `sm{2,3,4}.c`.

tested with `wolfssl-multi-test.sh ... quantum-safe-wolfssl-cross-aarch64-armasm-unittest-sanitizer quantum-safe-wolfssl-all-cross-armv7a-armasm-unittest` with `-DTEST_LIBWOLFSSL_SOURCES_INCLUSION_SEQUENCE` (both of those enable wolfsm)
