### PR TITLE
Introduce sm-cipher workflow tests to wolfsm

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,12 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a vulnerability, please report it to support@wolfssl.com
+
+ 1. Include a detailed description
+ 2. Include method to reproduce and/or method of discovery
+ 3. We will evaluate the report promptly and respond to you with findings.
+ 4. We will credit you with the report if you would like.
+
+**Please keep the vulnerability private** until a fix has been released.

--- a/.github/workflows/sm-cipher.yml
+++ b/.github/workflows/sm-cipher.yml
@@ -1,0 +1,194 @@
+name: SM Cipher Test (2 of 2)
+#
+# Test fetches wolfssl-examples/Arduino and uses local, latest github master branch wolfssl
+#
+# These 4 workflows across 3 repos are interdependent for the current $REPO_OWNER:
+#
+# sm-cipher CI Build 1: https://github.com/$REPO_OWNER/wolfssl      #  /.github/workflows/sm-cipher.yml
+#   - Builds SM-enabled library from local clone of wolfssl master branch
+#   - Fetches examples from https://github.com/$REPO_OWNER/wolfsm
+#
+# THIS sm-cipher CI Build 2: https://github.com/$REPO_OWNER/wolfsm  #  /.github/workflows/sm-cipher.yml
+#   - Builds SM-enabled library from fresh clone of wolfssl master branch here
+#
+#                                   ** NOTE TO MAINTAINERS **
+#
+#           Consider using winmerge or similar tool to keep the 2 sm-cipher.yml files in relative sync.
+#           Although there are some specific differences, most of the contents are otherwise identical.
+#
+
+# START OF COMMON SECTION
+on:
+  push:
+    branches: [ '**', 'master', 'main', 'release/**' ]
+    paths:
+      - '.github/workflows/sm-cipher.yml'
+      - './**'
+  pull_request:
+    # Run after merge on protected branches
+    branches: [ "main", "master", "release/**" ]
+    paths:
+      - '.github/workflows/sm-cipher.yml'
+      - './**'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+# END OF COMMON SECTION
+
+jobs:
+  build:
+    if: github.repository_owner == 'wolfssl'
+    runs-on: ubuntu-latest
+    env:
+      REPO_OWNER: ${{ github.repository_owner }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set job environment variables
+        run: |
+          # Script to assign some common environment variables after everything is installed
+
+          ICON_OK=$(printf "\xE2\x9C\x85")
+          ICON_FAIL=$(printf "\xE2\x9D\x8C")
+
+          # Show predefined summary:
+
+          # For the wolfssl repo, the GITHUB_WORKSPACE is the directory of wolfssl
+          echo "GITHUB_WORKSPACE       = $GITHUB_WORKSPACE"
+
+          # Show assigned build:env values (e.g. "wolfssl", "gojimmpi" or other owners):
+          echo "REPO_OWNER             = $REPO_OWNER"
+
+          # Update environment variables, not available here in this step yet
+          echo "GITHUB_WORK=$(realpath  "$GITHUB_WORKSPACE/../..")"       >> "$GITHUB_ENV"
+          echo "WOLFSM_ROOT=$(realpath  "$GITHUB_WORKSPACE/../wolfsm")"   >> "$GITHUB_ENV"
+          echo "WOLFSSL_ROOT=$(realpath "$GITHUB_WORKSPACE/../wolfssl")"  >> "$GITHUB_ENV"
+
+          echo "GITHUB_ENV=$GITHUB_ENV"
+
+          git status
+
+          echo "contents..."
+          # typically "/home/runner/work/wolfssl/wolfssl" contains wolfssl source
+          pwd
+          ls
+          # ** END ** Set job environment variables
+
+      - name: Get wolfssl
+        run: |
+          # We are in wolfsm repo, fetch wolfssl code
+
+          # Show our custom values:
+          echo "GITHUB_WORK            = $GITHUB_WORK"
+
+          # WOLFSM_ROOT is the repo root for wolfsm clone
+          echo "WOLFSM_ROOT            = $WOLFSM_ROOT"
+
+          echo "Start pwd:"
+          pwd
+          # we're typically in $GITHUB_WORKSPACE=/home/runner/work/wolfssl/wolfssl
+          # goto /home/runner/work to fetch wolfsm
+
+          echo "Current pwd for wolfsm clone fetch: $(pwd)"
+          GITHUB_WORK=$(realpath "$GITHUB_WORKSPACE/../..")
+          echo "GITHUB_WORKSPACE=$GITHUB_WORKSPACE"
+
+
+          pushd ../
+            echo "Updated pwd for wolfssl clone fetch: $(pwd)"
+
+            echo "clone --depth 1 https://github.com/$REPO_OWNER/wolfssl.git wolfssl"
+
+            git   clone --depth 1 https://github.com/$REPO_OWNER/wolfssl.git wolfssl
+
+            cd ./wolfssl
+            echo "Contents of this path for wolfssl = $(pwd)"
+            ls
+          popd
+
+          # ** END ** Get wolfssl
+
+      - name: Install wolfsm
+        run: |
+          # Run the local install.sh install script to install wolfsm code
+
+          echo "Current pwd for wolfsm clone fetch: $(pwd)"
+          GITHUB_WORK=$(realpath "$GITHUB_WORKSPACE/../..")
+          echo "GITHUB_WORKSPACE=$GITHUB_WORKSPACE"
+
+          # Typically /home/runner/work
+          echo "GITHUB_WORK=$GITHUB_WORK"
+          pwd
+          echo "pushd $WOLFSM_ROOT"
+          pushd "$WOLFSM_ROOT"
+            pwd
+            ls
+
+            echo "wolfssl check"
+            ls ../wolfssl
+
+            echo "Call wolfsm/install.sh to install wolfsm code into $WOLFSSL_ROOT"
+            ./install.sh "$WOLFSSL_ROOT"
+          popd
+
+          echo "contents..."
+          pwd
+          ls
+
+          # ** END ** Install wolfsm
+
+      - name: Compile wolfssl
+        run: |
+          # Compile fresh wolfSSL with wolfsm code
+
+          cd "$WOLFSSL_ROOT"
+          echo "Current directory:           $PWD"
+
+          ./autogen.sh
+          ./configure --enable-sm3 --enable-sm4-ecb --enable-sm4-cbc --enable-sm4-ctr --enable-sm4-gcm --enable-sm4-ccm --enable-sm2
+          make
+
+          # ** END ** Compile wolfssl
+
+      - name: make check
+        run: |
+          # make check
+
+          cd "$WOLFSSL_ROOT"
+          echo "Current directory:           $PWD"
+
+          make check
+
+          # ** END ** make check
+
+      - name: Unit test
+        run: |
+          # Run unit.test ./tests/test-sm2.conf
+
+          cd "$WOLFSSL_ROOT"
+          echo "Current directory:           $PWD"
+
+          echo "looking for test-sm2.conf"
+          ls ./tests/test-sm2.conf
+
+          echo "Run unit test: ./tests/unit.test ./tests/test-sm2.conf"
+          ./tests/unit.test ./tests/test-sm2.conf
+
+          # ** END ** Unit test
+
+      - name: Run SM benchmark
+        shell: bash
+        run: |
+          # Run benchmark from cloned wolfssl directory
+
+          cd "$WOLFSSL_ROOT"
+          echo "Current directory:           $PWD"
+
+          set -euo pipefail
+
+          ./wolfcrypt/benchmark/benchmark
+
+          # ** END ** un SM benchmark

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+﻿# Visual Studio
+/.vs
+
+# Visual Studio Code Workspace Files
+*.vscode
+
+# Backup files
+*.bak


### PR DESCRIPTION
This PR introduces SM cipher tests in GitHub workflow for the wolfsm repo. 

~~The SM TLS 1.3 is currently not working properly; Thus this PR can be merged as-is to show that, or wait until~~ [#9175](https://github.com/wolfSSL/wolfssl/pull/9175) is merged.

See sample action history: https://github.com/gojimmypi/wolfsm/actions/workflows/sm-cipher.yml

See also: 
- https://github.com/wolfSSL/wolfssl/issues/9169
- https://github.com/wolfSSL/wolfssl/pull/9175
- https://github.com/wolfSSL/wolfssl/pull/6825
- https://github.com/wolfSSL/wolfssl/pull/9193
- https://github.com/wolfSSL/wolfssl/pull/9190
- https://github.com/wolfSSL/wolfssl/issues/9187

I also have a [WIP wolfssl companion](https://github.com/gojimmypi/wolfssl/blob/espressif-latest-debug/.github/workflows/sm-cipher.yml) test. See [sample](https://github.com/gojimmypi/wolfssl/actions/workflows/sm-cipher.yml) for that. 

SM tests are passing there as I manually applied the patch from https://github.com/wolfSSL/wolfssl/pull/9175

